### PR TITLE
Fix ROS packaging again

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "lint:ci": "eslint --report-unused-disable-directives .",
     "lint": "eslint --report-unused-disable-directives --fix .",
     "test": "jest",
-    "update-generated-files": "ts-node --files --project tsconfig.cjs.json scripts/updateGeneratedFiles -o schemas"
+    "update-generated-files": "ts-node --files --project tsconfig.cjs.json scripts/updateGeneratedFiles --out-dir schemas --ros-out-dir ros_foxglove_msgs"
   },
   "devDependencies": {
     "@foxglove/eslint-plugin": "0.19.0",

--- a/ros_foxglove_msgs/CMakeLists.txt
+++ b/ros_foxglove_msgs/CMakeLists.txt
@@ -20,17 +20,18 @@ if(${ROS_VERSION} EQUAL 1)
 
   # Copy .msg files into a msg/ folder, so that add_message_files installs them
   # into share/${project_name}/msg.
-  file(GLOB _generated_ros1_schemas RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" ../schemas/ros1/*)
-  message(STATUS "Using msg files: ${_generated_ros1_schemas}")
-  if(NOT _generated_ros1_schemas)
-    message(FATAL_ERROR "No msg files found")
-  endif()
   file(REMOVE_RECURSE msg)
+  file(COPY ros1 DESTINATION "${CMAKE_CURRENT_SOURCE_DIR}/msg")
   file(COPY
-    ${_generated_ros1_schemas}
     ImageMarkerArray.msg
     DESTINATION "${CMAKE_CURRENT_SOURCE_DIR}/msg"
   )
+  file(GLOB _all_msg_files RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" msg/*)
+  message(STATUS "Using msg files: ${_all_msg_files}")
+  if(NOT _all_msg_files)
+    message(FATAL_ERROR "No msg files found")
+  endif()
+
   add_message_files(DIRECTORY msg)
 
   generate_messages(DEPENDENCIES visualization_msgs geometry_msgs)
@@ -62,10 +63,9 @@ elseif(${ROS_VERSION} EQUAL 2)
   # Copy .msg files into a msg/ folder, so that rosidl_generate_interfaces
   # installs them into share/${project_name}/msg. Subdirectories not named "msg"
   # will confuse various tooling like rosbridge_server and rosbag2_storage_mcap.
-  file(GLOB _generated_ros2_schemas RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" ../schemas/ros2/*)
   file(REMOVE_RECURSE msg)
+  file(COPY ros2 DESTINATION "${CMAKE_CURRENT_SOURCE_DIR}/msg")
   file(COPY
-    ${_generated_ros2_schemas}
     ImageMarkerArray.msg
     DESTINATION "${CMAKE_CURRENT_SOURCE_DIR}/msg"
   )
@@ -74,6 +74,7 @@ elseif(${ROS_VERSION} EQUAL 2)
   if(NOT _all_msg_files)
     message(FATAL_ERROR "No msg files found")
   endif()
+  
   rosidl_generate_interfaces(${PROJECT_NAME}
     ${_all_msg_files}
     DEPENDENCIES visualization_msgs geometry_msgs

--- a/ros_foxglove_msgs/CMakeLists.txt
+++ b/ros_foxglove_msgs/CMakeLists.txt
@@ -72,13 +72,13 @@ elseif(${ROS_VERSION} EQUAL 2)
     ImageMarkerArray.msg
     DESTINATION "${CMAKE_CURRENT_SOURCE_DIR}/msg"
   )
-  
+
   file(GLOB _all_msg_files RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" msg/*)
   message(STATUS "Using msg files: ${_all_msg_files}")
   if(NOT _all_msg_files)
     message(FATAL_ERROR "No msg files found")
   endif()
-  
+
   rosidl_generate_interfaces(${PROJECT_NAME}
     ${_all_msg_files}
     DEPENDENCIES visualization_msgs geometry_msgs

--- a/ros_foxglove_msgs/CMakeLists.txt
+++ b/ros_foxglove_msgs/CMakeLists.txt
@@ -20,12 +20,14 @@ if(${ROS_VERSION} EQUAL 1)
 
   # Copy .msg files into a msg/ folder, so that add_message_files installs them
   # into share/${project_name}/msg.
+  file(GLOB _generated_ros1_schemas ros1/*)
   file(REMOVE_RECURSE msg)
-  file(COPY ros1 DESTINATION "${CMAKE_CURRENT_SOURCE_DIR}/msg")
   file(COPY
+    ${_generated_ros1_schemas}
     ImageMarkerArray.msg
     DESTINATION "${CMAKE_CURRENT_SOURCE_DIR}/msg"
   )
+
   file(GLOB _all_msg_files RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" msg/*)
   message(STATUS "Using msg files: ${_all_msg_files}")
   if(NOT _all_msg_files)
@@ -63,12 +65,14 @@ elseif(${ROS_VERSION} EQUAL 2)
   # Copy .msg files into a msg/ folder, so that rosidl_generate_interfaces
   # installs them into share/${project_name}/msg. Subdirectories not named "msg"
   # will confuse various tooling like rosbridge_server and rosbag2_storage_mcap.
+  file(GLOB _generated_ros2_schemas ros2/*)
   file(REMOVE_RECURSE msg)
-  file(COPY ros2 DESTINATION "${CMAKE_CURRENT_SOURCE_DIR}/msg")
   file(COPY
+    ${_generated_ros2_schemas}
     ImageMarkerArray.msg
     DESTINATION "${CMAKE_CURRENT_SOURCE_DIR}/msg"
   )
+  
   file(GLOB _all_msg_files RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" msg/*)
   message(STATUS "Using msg files: ${_all_msg_files}")
   if(NOT _all_msg_files)

--- a/ros_foxglove_msgs/ros1/CameraCalibration.msg
+++ b/ros_foxglove_msgs/ros1/CameraCalibration.msg
@@ -1,0 +1,61 @@
+# Generated from CameraCalibration by @foxglove/schemas
+
+# Timestamp of calibration data
+time timestamp
+
+# Image width
+uint32 width
+
+# Image height
+uint32 height
+
+# Name of distortion model
+string distortion_model
+
+# Distortion parameters
+float64[] D
+
+# Intrinsic camera matrix (3x3 row-major matrix)
+# 
+# A 3x3 row-major matrix for the raw (distorted) image.
+# 
+# Projects 3D points in the camera coordinate frame to 2D pixel coordinates using the focal lengths (fx, fy) and principal point (cx, cy).
+# 
+# ```
+#     [fx  0 cx]
+# K = [ 0 fy cy]
+#     [ 0  0  1]
+# ```
+float64[9] K
+
+# Rectification matrix (3x3 row-major matrix)
+# 
+# A rotation matrix aligning the camera coordinate system to the ideal stereo image plane so that epipolar lines in both stereo images are parallel.
+float64[9] R
+
+# Projection/camera matrix (3x4 row-major matrix)
+# 
+# ```
+#     [fx'  0  cx' Tx]
+# P = [ 0  fy' cy' Ty]
+#     [ 0   0   1   0]
+# ```
+# 
+# By convention, this matrix specifies the intrinsic (camera) matrix of the processed (rectified) image. That is, the left 3x3 portion is the normal camera intrinsic matrix for the rectified image.
+# 
+# It projects 3D points in the camera coordinate frame to 2D pixel coordinates using the focal lengths (fx', fy') and principal point (cx', cy') - these may differ from the values in K.
+# 
+# For monocular cameras, Tx = Ty = 0. Normally, monocular cameras will also have R = the identity and P[1:3,1:3] = K.
+# 
+# For a stereo pair, the fourth column [Tx Ty 0]' is related to the position of the optical center of the second camera in the first camera's frame. We assume Tz = 0 so both cameras are in the same stereo image plane. The first camera always has Tx = Ty = 0. For the right (second) camera of a horizontal stereo pair, Ty = 0 and Tx = -fx' * B, where B is the baseline between the cameras.
+# 
+# Given a 3D point [X Y Z]', the projection (x, y) of the point onto the rectified image is given by:
+# 
+# ```
+# [u v w]' = P * [X Y Z 1]'
+#        x = u / w
+#        y = v / w
+# ```
+# 
+# This holds for both images of a stereo pair.
+float64[12] P

--- a/ros_foxglove_msgs/ros1/CircleAnnotation.msg
+++ b/ros_foxglove_msgs/ros1/CircleAnnotation.msg
@@ -1,0 +1,19 @@
+# Generated from CircleAnnotation by @foxglove/schemas
+
+# Timestamp of circle
+time timestamp
+
+# Center of the circle in 2D image coordinates
+foxglove_msgs/Point2 position
+
+# Circle diameter
+float64 diameter
+
+# Line thickness
+float64 thickness
+
+# Fill color
+foxglove_msgs/Color fill_color
+
+# Outline color
+foxglove_msgs/Color outline_color

--- a/ros_foxglove_msgs/ros1/Color.msg
+++ b/ros_foxglove_msgs/ros1/Color.msg
@@ -1,0 +1,13 @@
+# Generated from Color by @foxglove/schemas
+
+# Red value between 0 and 1
+float64 r
+
+# Green value between 0 and 1
+float64 g
+
+# Blue value between 0 and 1
+float64 b
+
+# Alpha value between 0 and 1
+float64 a

--- a/ros_foxglove_msgs/ros1/CompressedImage.msg
+++ b/ros_foxglove_msgs/ros1/CompressedImage.msg
@@ -1,0 +1,10 @@
+# Generated from CompressedImage by @foxglove/schemas
+
+# Timestamp of image
+time timestamp
+
+# Compressed image data
+uint8[] data
+
+# Image format
+string format

--- a/ros_foxglove_msgs/ros1/FrameTransform.msg
+++ b/ros_foxglove_msgs/ros1/FrameTransform.msg
@@ -1,0 +1,13 @@
+# Generated from FrameTransform by @foxglove/schemas
+
+# Timestamp of transform
+time timestamp
+
+# Name of the parent frame
+string parent_frame_id
+
+# Name of the child frame
+string child_frame_id
+
+# Transform from parent frame to child frame
+foxglove_msgs/Transform transform

--- a/ros_foxglove_msgs/ros1/GeoJSON.msg
+++ b/ros_foxglove_msgs/ros1/GeoJSON.msg
@@ -1,0 +1,4 @@
+# Generated from GeoJSON by @foxglove/schemas
+
+# GeoJSON data encoded as a UTF-8 string
+string geojson

--- a/ros_foxglove_msgs/ros1/Grid.msg
+++ b/ros_foxglove_msgs/ros1/Grid.msg
@@ -1,0 +1,28 @@
+# Generated from Grid by @foxglove/schemas
+
+# Timestamp of grid
+time timestamp
+
+# Frame of reference
+string frame_id
+
+# Origin of grid's corner relative to frame of reference; grid is positioned in the x-y plane relative to this origin
+geometry_msgs/Pose pose
+
+# Number of grid columns
+uint32 column_count
+
+# Size of single grid cell along x and y axes, relative to `pose`
+foxglove_msgs/Vector2 cell_size
+
+# Number of bytes between rows in `data`
+uint32 row_stride
+
+# Number of bytes between cells within a row in `data`
+uint32 cell_stride
+
+# Fields in `data`
+foxglove_msgs/PackedElementField[] fields
+
+# Grid cell data, interpreted using `fields`, in row-major (y-major) order
+uint8[] data

--- a/ros_foxglove_msgs/ros1/ImageAnnotations.msg
+++ b/ros_foxglove_msgs/ros1/ImageAnnotations.msg
@@ -1,0 +1,7 @@
+# Generated from ImageAnnotations by @foxglove/schemas
+
+# Circle annotations
+foxglove_msgs/CircleAnnotation[] circles
+
+# Points annotations
+foxglove_msgs/PointsAnnotation[] points

--- a/ros_foxglove_msgs/ros1/LaserScan.msg
+++ b/ros_foxglove_msgs/ros1/LaserScan.msg
@@ -1,0 +1,22 @@
+# Generated from LaserScan by @foxglove/schemas
+
+# Timestamp of scan
+time timestamp
+
+# Frame of reference
+string frame_id
+
+# Origin of scan relative to frame of reference; points are positioned in the x-y plane relative to this origin; angles are interpreted as counterclockwise rotations around the z axis with 0 rad being in the +x direction
+geometry_msgs/Pose pose
+
+# Bearing of first point, in radians
+float64 start_angle
+
+# Bearing of last point, in radians
+float64 end_angle
+
+# Distance of detections from origin; assumed to be at equally-spaced angles between `start_angle` and `end_angle`
+float64[] ranges
+
+# Intensity of detections
+float64[] intensities

--- a/ros_foxglove_msgs/ros1/LocationFix.msg
+++ b/ros_foxglove_msgs/ros1/LocationFix.msg
@@ -1,0 +1,21 @@
+# Generated from LocationFix by @foxglove/schemas
+
+# Latitude in degrees
+float64 latitude
+
+# Longitude in degrees
+float64 longitude
+
+# Altitude in meters
+float64 altitude
+
+# Position covariance (m^2) defined relative to a tangential plane through the reported position. The components are East, North, and Up (ENU), in row-major order.
+float64[9] position_covariance
+
+uint8 UNKNOWN=0
+uint8 APPROXIMATED=1
+uint8 DIAGONAL_KNOWN=2
+uint8 KNOWN=3
+
+# If `position_covariance` is available, `position_covariance_type` must be set to indicate the type of covariance.
+uint8 position_covariance_type

--- a/ros_foxglove_msgs/ros1/Log.msg
+++ b/ros_foxglove_msgs/ros1/Log.msg
@@ -1,0 +1,26 @@
+# Generated from Log by @foxglove/schemas
+
+# Timestamp of log message
+time timestamp
+
+uint8 UNKNOWN=0
+uint8 DEBUG=1
+uint8 INFO=2
+uint8 WARNING=3
+uint8 ERROR=4
+uint8 FATAL=5
+
+# Log level
+uint8 level
+
+# Log message
+string message
+
+# Process or node name
+string name
+
+# Filename
+string file
+
+# Line number in the file
+uint32 line

--- a/ros_foxglove_msgs/ros1/PackedElementField.msg
+++ b/ros_foxglove_msgs/ros1/PackedElementField.msg
@@ -1,0 +1,20 @@
+# Generated from PackedElementField by @foxglove/schemas
+
+# Name of the field
+string name
+
+# Byte offset from start of data buffer
+uint32 offset
+
+uint8 UNKNOWN=0
+uint8 UINT8=1
+uint8 INT8=2
+uint8 UINT16=3
+uint8 INT16=4
+uint8 UINT32=5
+uint8 INT32=6
+uint8 FLOAT32=7
+uint8 FLOAT64=8
+
+# Type of data in the field. Integers are stored using little-endian byte order.
+uint8 type

--- a/ros_foxglove_msgs/ros1/Point2.msg
+++ b/ros_foxglove_msgs/ros1/Point2.msg
@@ -1,0 +1,7 @@
+# Generated from Point2 by @foxglove/schemas
+
+# x coordinate position
+float64 x
+
+# y coordinate position
+float64 y

--- a/ros_foxglove_msgs/ros1/PointCloud.msg
+++ b/ros_foxglove_msgs/ros1/PointCloud.msg
@@ -1,0 +1,19 @@
+# Generated from PointCloud by @foxglove/schemas
+
+# Timestamp of point cloud
+time timestamp
+
+# Frame of reference
+string frame_id
+
+# The origin of the point cloud relative to the frame of reference
+geometry_msgs/Pose pose
+
+# Number of bytes between points in the `data`
+uint32 point_stride
+
+# Fields in the `data`
+foxglove_msgs/PackedElementField[] fields
+
+# Point data, interpreted using `fields`
+uint8[] data

--- a/ros_foxglove_msgs/ros1/PointsAnnotation.msg
+++ b/ros_foxglove_msgs/ros1/PointsAnnotation.msg
@@ -1,0 +1,22 @@
+# Generated from PointsAnnotation by @foxglove/schemas
+
+# Timestamp of annotation
+time timestamp
+
+uint8 UNKNOWN=0
+uint8 POINTS=1
+uint8 LINE_LOOP=2
+uint8 LINE_STRIP=3
+uint8 LINE_LIST=4
+
+# Type of points annotation to draw
+uint8 type
+
+# Points in 2D image coordinates
+foxglove_msgs/Point2[] points
+
+# Outline colors
+foxglove_msgs/Color[] outline_colors
+
+# Fill color
+foxglove_msgs/Color fill_color

--- a/ros_foxglove_msgs/ros1/PoseInFrame.msg
+++ b/ros_foxglove_msgs/ros1/PoseInFrame.msg
@@ -1,0 +1,10 @@
+# Generated from PoseInFrame by @foxglove/schemas
+
+# Timestamp of pose
+time timestamp
+
+# Frame of reference for pose position and orientation
+string frame_id
+
+# Pose in 3D space
+geometry_msgs/Pose pose

--- a/ros_foxglove_msgs/ros1/PosesInFrame.msg
+++ b/ros_foxglove_msgs/ros1/PosesInFrame.msg
@@ -1,0 +1,10 @@
+# Generated from PosesInFrame by @foxglove/schemas
+
+# Timestamp of pose
+time timestamp
+
+# Frame of reference for pose position and orientation
+string frame_id
+
+# Poses in 3D space
+geometry_msgs/Pose[] poses

--- a/ros_foxglove_msgs/ros1/RawImage.msg
+++ b/ros_foxglove_msgs/ros1/RawImage.msg
@@ -1,0 +1,19 @@
+# Generated from RawImage by @foxglove/schemas
+
+# Timestamp of image
+time timestamp
+
+# Image width
+uint32 width
+
+# Image height
+uint32 height
+
+# Encoding of the raw image data
+string encoding
+
+# Byte length of a single row
+uint32 step
+
+# Raw image data
+uint8[] data

--- a/ros_foxglove_msgs/ros1/Transform.msg
+++ b/ros_foxglove_msgs/ros1/Transform.msg
@@ -1,0 +1,10 @@
+# Generated from Transform by @foxglove/schemas
+
+# Transform time
+time timestamp
+
+# Translation component of the transform
+geometry_msgs/Vector3 translation
+
+# Rotation component of the transform
+geometry_msgs/Quaternion rotation

--- a/ros_foxglove_msgs/ros1/Vector2.msg
+++ b/ros_foxglove_msgs/ros1/Vector2.msg
@@ -1,0 +1,7 @@
+# Generated from Vector2 by @foxglove/schemas
+
+# x coordinate length
+float64 x
+
+# y coordinate length
+float64 y

--- a/ros_foxglove_msgs/ros2/CameraCalibration.msg
+++ b/ros_foxglove_msgs/ros2/CameraCalibration.msg
@@ -1,0 +1,61 @@
+# Generated from CameraCalibration by @foxglove/schemas
+
+# Timestamp of calibration data
+builtin_interfaces/Time timestamp
+
+# Image width
+uint32 width
+
+# Image height
+uint32 height
+
+# Name of distortion model
+string distortion_model
+
+# Distortion parameters
+float64[] d
+
+# Intrinsic camera matrix (3x3 row-major matrix)
+# 
+# A 3x3 row-major matrix for the raw (distorted) image.
+# 
+# Projects 3D points in the camera coordinate frame to 2D pixel coordinates using the focal lengths (fx, fy) and principal point (cx, cy).
+# 
+# ```
+#     [fx  0 cx]
+# K = [ 0 fy cy]
+#     [ 0  0  1]
+# ```
+float64[9] k
+
+# Rectification matrix (3x3 row-major matrix)
+# 
+# A rotation matrix aligning the camera coordinate system to the ideal stereo image plane so that epipolar lines in both stereo images are parallel.
+float64[9] r
+
+# Projection/camera matrix (3x4 row-major matrix)
+# 
+# ```
+#     [fx'  0  cx' Tx]
+# P = [ 0  fy' cy' Ty]
+#     [ 0   0   1   0]
+# ```
+# 
+# By convention, this matrix specifies the intrinsic (camera) matrix of the processed (rectified) image. That is, the left 3x3 portion is the normal camera intrinsic matrix for the rectified image.
+# 
+# It projects 3D points in the camera coordinate frame to 2D pixel coordinates using the focal lengths (fx', fy') and principal point (cx', cy') - these may differ from the values in K.
+# 
+# For monocular cameras, Tx = Ty = 0. Normally, monocular cameras will also have R = the identity and P[1:3,1:3] = K.
+# 
+# For a stereo pair, the fourth column [Tx Ty 0]' is related to the position of the optical center of the second camera in the first camera's frame. We assume Tz = 0 so both cameras are in the same stereo image plane. The first camera always has Tx = Ty = 0. For the right (second) camera of a horizontal stereo pair, Ty = 0 and Tx = -fx' * B, where B is the baseline between the cameras.
+# 
+# Given a 3D point [X Y Z]', the projection (x, y) of the point onto the rectified image is given by:
+# 
+# ```
+# [u v w]' = P * [X Y Z 1]'
+#        x = u / w
+#        y = v / w
+# ```
+# 
+# This holds for both images of a stereo pair.
+float64[12] p

--- a/ros_foxglove_msgs/ros2/CircleAnnotation.msg
+++ b/ros_foxglove_msgs/ros2/CircleAnnotation.msg
@@ -1,0 +1,19 @@
+# Generated from CircleAnnotation by @foxglove/schemas
+
+# Timestamp of circle
+builtin_interfaces/Time timestamp
+
+# Center of the circle in 2D image coordinates
+foxglove_msgs/Point2 position
+
+# Circle diameter
+float64 diameter
+
+# Line thickness
+float64 thickness
+
+# Fill color
+foxglove_msgs/Color fill_color
+
+# Outline color
+foxglove_msgs/Color outline_color

--- a/ros_foxglove_msgs/ros2/Color.msg
+++ b/ros_foxglove_msgs/ros2/Color.msg
@@ -1,0 +1,13 @@
+# Generated from Color by @foxglove/schemas
+
+# Red value between 0 and 1
+float64 r
+
+# Green value between 0 and 1
+float64 g
+
+# Blue value between 0 and 1
+float64 b
+
+# Alpha value between 0 and 1
+float64 a

--- a/ros_foxglove_msgs/ros2/CompressedImage.msg
+++ b/ros_foxglove_msgs/ros2/CompressedImage.msg
@@ -1,0 +1,10 @@
+# Generated from CompressedImage by @foxglove/schemas
+
+# Timestamp of image
+builtin_interfaces/Time timestamp
+
+# Compressed image data
+uint8[] data
+
+# Image format
+string format

--- a/ros_foxglove_msgs/ros2/FrameTransform.msg
+++ b/ros_foxglove_msgs/ros2/FrameTransform.msg
@@ -1,0 +1,13 @@
+# Generated from FrameTransform by @foxglove/schemas
+
+# Timestamp of transform
+builtin_interfaces/Time timestamp
+
+# Name of the parent frame
+string parent_frame_id
+
+# Name of the child frame
+string child_frame_id
+
+# Transform from parent frame to child frame
+foxglove_msgs/Transform transform

--- a/ros_foxglove_msgs/ros2/GeoJSON.msg
+++ b/ros_foxglove_msgs/ros2/GeoJSON.msg
@@ -1,0 +1,4 @@
+# Generated from GeoJSON by @foxglove/schemas
+
+# GeoJSON data encoded as a UTF-8 string
+string geojson

--- a/ros_foxglove_msgs/ros2/Grid.msg
+++ b/ros_foxglove_msgs/ros2/Grid.msg
@@ -1,0 +1,28 @@
+# Generated from Grid by @foxglove/schemas
+
+# Timestamp of grid
+builtin_interfaces/Time timestamp
+
+# Frame of reference
+string frame_id
+
+# Origin of grid's corner relative to frame of reference; grid is positioned in the x-y plane relative to this origin
+geometry_msgs/Pose pose
+
+# Number of grid columns
+uint32 column_count
+
+# Size of single grid cell along x and y axes, relative to `pose`
+foxglove_msgs/Vector2 cell_size
+
+# Number of bytes between rows in `data`
+uint32 row_stride
+
+# Number of bytes between cells within a row in `data`
+uint32 cell_stride
+
+# Fields in `data`
+foxglove_msgs/PackedElementField[] fields
+
+# Grid cell data, interpreted using `fields`, in row-major (y-major) order
+uint8[] data

--- a/ros_foxglove_msgs/ros2/ImageAnnotations.msg
+++ b/ros_foxglove_msgs/ros2/ImageAnnotations.msg
@@ -1,0 +1,7 @@
+# Generated from ImageAnnotations by @foxglove/schemas
+
+# Circle annotations
+foxglove_msgs/CircleAnnotation[] circles
+
+# Points annotations
+foxglove_msgs/PointsAnnotation[] points

--- a/ros_foxglove_msgs/ros2/LaserScan.msg
+++ b/ros_foxglove_msgs/ros2/LaserScan.msg
@@ -1,0 +1,22 @@
+# Generated from LaserScan by @foxglove/schemas
+
+# Timestamp of scan
+builtin_interfaces/Time timestamp
+
+# Frame of reference
+string frame_id
+
+# Origin of scan relative to frame of reference; points are positioned in the x-y plane relative to this origin; angles are interpreted as counterclockwise rotations around the z axis with 0 rad being in the +x direction
+geometry_msgs/Pose pose
+
+# Bearing of first point, in radians
+float64 start_angle
+
+# Bearing of last point, in radians
+float64 end_angle
+
+# Distance of detections from origin; assumed to be at equally-spaced angles between `start_angle` and `end_angle`
+float64[] ranges
+
+# Intensity of detections
+float64[] intensities

--- a/ros_foxglove_msgs/ros2/LocationFix.msg
+++ b/ros_foxglove_msgs/ros2/LocationFix.msg
@@ -1,0 +1,21 @@
+# Generated from LocationFix by @foxglove/schemas
+
+# Latitude in degrees
+float64 latitude
+
+# Longitude in degrees
+float64 longitude
+
+# Altitude in meters
+float64 altitude
+
+# Position covariance (m^2) defined relative to a tangential plane through the reported position. The components are East, North, and Up (ENU), in row-major order.
+float64[9] position_covariance
+
+uint8 UNKNOWN=0
+uint8 APPROXIMATED=1
+uint8 DIAGONAL_KNOWN=2
+uint8 KNOWN=3
+
+# If `position_covariance` is available, `position_covariance_type` must be set to indicate the type of covariance.
+uint8 position_covariance_type

--- a/ros_foxglove_msgs/ros2/Log.msg
+++ b/ros_foxglove_msgs/ros2/Log.msg
@@ -1,0 +1,26 @@
+# Generated from Log by @foxglove/schemas
+
+# Timestamp of log message
+builtin_interfaces/Time timestamp
+
+uint8 UNKNOWN=0
+uint8 DEBUG=1
+uint8 INFO=2
+uint8 WARNING=3
+uint8 ERROR=4
+uint8 FATAL=5
+
+# Log level
+uint8 level
+
+# Log message
+string message
+
+# Process or node name
+string name
+
+# Filename
+string file
+
+# Line number in the file
+uint32 line

--- a/ros_foxglove_msgs/ros2/PackedElementField.msg
+++ b/ros_foxglove_msgs/ros2/PackedElementField.msg
@@ -1,0 +1,20 @@
+# Generated from PackedElementField by @foxglove/schemas
+
+# Name of the field
+string name
+
+# Byte offset from start of data buffer
+uint32 offset
+
+uint8 UNKNOWN=0
+uint8 UINT8=1
+uint8 INT8=2
+uint8 UINT16=3
+uint8 INT16=4
+uint8 UINT32=5
+uint8 INT32=6
+uint8 FLOAT32=7
+uint8 FLOAT64=8
+
+# Type of data in the field. Integers are stored using little-endian byte order.
+uint8 type

--- a/ros_foxglove_msgs/ros2/Point2.msg
+++ b/ros_foxglove_msgs/ros2/Point2.msg
@@ -1,0 +1,7 @@
+# Generated from Point2 by @foxglove/schemas
+
+# x coordinate position
+float64 x
+
+# y coordinate position
+float64 y

--- a/ros_foxglove_msgs/ros2/PointCloud.msg
+++ b/ros_foxglove_msgs/ros2/PointCloud.msg
@@ -1,0 +1,19 @@
+# Generated from PointCloud by @foxglove/schemas
+
+# Timestamp of point cloud
+builtin_interfaces/Time timestamp
+
+# Frame of reference
+string frame_id
+
+# The origin of the point cloud relative to the frame of reference
+geometry_msgs/Pose pose
+
+# Number of bytes between points in the `data`
+uint32 point_stride
+
+# Fields in the `data`
+foxglove_msgs/PackedElementField[] fields
+
+# Point data, interpreted using `fields`
+uint8[] data

--- a/ros_foxglove_msgs/ros2/PointsAnnotation.msg
+++ b/ros_foxglove_msgs/ros2/PointsAnnotation.msg
@@ -1,0 +1,22 @@
+# Generated from PointsAnnotation by @foxglove/schemas
+
+# Timestamp of annotation
+builtin_interfaces/Time timestamp
+
+uint8 UNKNOWN=0
+uint8 POINTS=1
+uint8 LINE_LOOP=2
+uint8 LINE_STRIP=3
+uint8 LINE_LIST=4
+
+# Type of points annotation to draw
+uint8 type
+
+# Points in 2D image coordinates
+foxglove_msgs/Point2[] points
+
+# Outline colors
+foxglove_msgs/Color[] outline_colors
+
+# Fill color
+foxglove_msgs/Color fill_color

--- a/ros_foxglove_msgs/ros2/PoseInFrame.msg
+++ b/ros_foxglove_msgs/ros2/PoseInFrame.msg
@@ -1,0 +1,10 @@
+# Generated from PoseInFrame by @foxglove/schemas
+
+# Timestamp of pose
+builtin_interfaces/Time timestamp
+
+# Frame of reference for pose position and orientation
+string frame_id
+
+# Pose in 3D space
+geometry_msgs/Pose pose

--- a/ros_foxglove_msgs/ros2/PosesInFrame.msg
+++ b/ros_foxglove_msgs/ros2/PosesInFrame.msg
@@ -1,0 +1,10 @@
+# Generated from PosesInFrame by @foxglove/schemas
+
+# Timestamp of pose
+builtin_interfaces/Time timestamp
+
+# Frame of reference for pose position and orientation
+string frame_id
+
+# Poses in 3D space
+geometry_msgs/Pose[] poses

--- a/ros_foxglove_msgs/ros2/RawImage.msg
+++ b/ros_foxglove_msgs/ros2/RawImage.msg
@@ -1,0 +1,19 @@
+# Generated from RawImage by @foxglove/schemas
+
+# Timestamp of image
+builtin_interfaces/Time timestamp
+
+# Image width
+uint32 width
+
+# Image height
+uint32 height
+
+# Encoding of the raw image data
+string encoding
+
+# Byte length of a single row
+uint32 step
+
+# Raw image data
+uint8[] data

--- a/ros_foxglove_msgs/ros2/Transform.msg
+++ b/ros_foxglove_msgs/ros2/Transform.msg
@@ -1,0 +1,10 @@
+# Generated from Transform by @foxglove/schemas
+
+# Transform time
+builtin_interfaces/Time timestamp
+
+# Translation component of the transform
+geometry_msgs/Vector3 translation
+
+# Rotation component of the transform
+geometry_msgs/Quaternion rotation

--- a/ros_foxglove_msgs/ros2/Vector2.msg
+++ b/ros_foxglove_msgs/ros2/Vector2.msg
@@ -1,0 +1,7 @@
+# Generated from Vector2 by @foxglove/schemas
+
+# x coordinate length
+float64 x
+
+# y coordinate length
+float64 y


### PR DESCRIPTION
Rework CMake setup again to avoid using `..` by copying generated files into the ros_foxglove_msgs dir. This is necessary because bloom-release will end up copying the ros_foxglove_msgs dir only, losing access to files from the parent dir during the final build.