### PR TITLE
Bump cmake_minimum_required for ROS 1

### DIFF
--- a/ros_foxglove_msgs/CMakeLists.txt
+++ b/ros_foxglove_msgs/CMakeLists.txt
@@ -3,7 +3,7 @@ find_package(ros_environment REQUIRED)
 set(ROS_VERSION $ENV{ROS_VERSION})
 
 if(${ROS_VERSION} EQUAL 1)
-  cmake_minimum_required(VERSION 2.8.3)
+  cmake_minimum_required(VERSION 3.0.2)
   project(foxglove_msgs)
 
   # Default to C++11


### PR DESCRIPTION
**Public-Facing Changes**
None

**Description**
Should fix a CMake warning from the build farm: https://build.ros.org/job/Ndev_db__foxglove_msgs__debian_buster_amd64/17/cmake/
https://wiki.ros.org/noetic/Migration#Increase_required_CMake_version_to_avoid_author_warning