### PR TITLE
Mark msg files in ros_foxglove_msgs as generated

### DIFF
--- a/ros_foxglove_msgs/.gitattributes
+++ b/ros_foxglove_msgs/.gitattributes
@@ -1,0 +1,2 @@
+ros1/** linguist-generated
+ros2/** linguist-generated


### PR DESCRIPTION
Reduces PR noise by hiding diffs for generated .msg files