### PR TITLE
Add missing documentation for PointsAnnotation `outline_color` and `thickness` fields

### DIFF
--- a/ros_foxglove_msgs/ros1/PointsAnnotation.msg
+++ b/ros_foxglove_msgs/ros1/PointsAnnotation.msg
@@ -18,8 +18,14 @@ uint8 type
 # Points in 2D image coordinates
 foxglove_msgs/Point2[] points
 
-# Outline colors
+# Outline color
+foxglove_msgs/Color outline_color
+
+# Per-point colors, if `type` is `POINTS`, or per-segment stroke colors, if `type` is `LINE_LIST`.
 foxglove_msgs/Color[] outline_colors
 
 # Fill color
 foxglove_msgs/Color fill_color
+
+# Stroke thickness
+float64 thickness

--- a/ros_foxglove_msgs/ros2/PointsAnnotation.msg
+++ b/ros_foxglove_msgs/ros2/PointsAnnotation.msg
@@ -18,8 +18,14 @@ uint8 type
 # Points in 2D image coordinates
 foxglove_msgs/Point2[] points
 
-# Outline colors
+# Outline color
+foxglove_msgs/Color outline_color
+
+# Per-point colors, if `type` is `POINTS`, or per-segment stroke colors, if `type` is `LINE_LIST`.
 foxglove_msgs/Color[] outline_colors
 
 # Fill color
 foxglove_msgs/Color fill_color
+
+# Stroke thickness
+float64 thickness

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -1274,6 +1274,19 @@ Points in 2D image coordinates
 </td>
 </tr>
 <tr>
+<td><code>outline_color</code></td>
+<td>
+
+[Color](#color)
+
+</td>
+<td>
+
+Outline color
+
+</td>
+</tr>
+<tr>
 <td><code>outline_colors</code></td>
 <td>
 
@@ -1282,7 +1295,7 @@ Points in 2D image coordinates
 </td>
 <td>
 
-Outline colors
+Per-point colors, if `type` is `POINTS`, or per-segment stroke colors, if `type` is `LINE_LIST`.
 
 </td>
 </tr>
@@ -1296,6 +1309,19 @@ Outline colors
 <td>
 
 Fill color
+
+</td>
+</tr>
+<tr>
+<td><code>thickness</code></td>
+<td>
+
+float64
+
+</td>
+<td>
+
+Stroke thickness
 
 </td>
 </tr>

--- a/schemas/jsonschema/ImageAnnotations.json
+++ b/schemas/jsonschema/ImageAnnotations.json
@@ -168,6 +168,29 @@
             },
             "description": "Points in 2D image coordinates"
           },
+          "outline_color": {
+            "title": "foxglove.Color",
+            "description": "Outline color",
+            "type": "object",
+            "properties": {
+              "r": {
+                "type": "number",
+                "description": "Red value between 0 and 1"
+              },
+              "g": {
+                "type": "number",
+                "description": "Green value between 0 and 1"
+              },
+              "b": {
+                "type": "number",
+                "description": "Blue value between 0 and 1"
+              },
+              "a": {
+                "type": "number",
+                "description": "Alpha value between 0 and 1"
+              }
+            }
+          },
           "outline_colors": {
             "type": "array",
             "items": {
@@ -193,7 +216,7 @@
                 }
               }
             },
-            "description": "Outline colors"
+            "description": "Per-point colors, if `type` is `POINTS`, or per-segment stroke colors, if `type` is `LINE_LIST`."
           },
           "fill_color": {
             "title": "foxglove.Color",
@@ -217,6 +240,10 @@
                 "description": "Alpha value between 0 and 1"
               }
             }
+          },
+          "thickness": {
+            "type": "number",
+            "description": "Stroke thickness"
           }
         }
       },

--- a/schemas/jsonschema/PointsAnnotation.json
+++ b/schemas/jsonschema/PointsAnnotation.json
@@ -65,6 +65,29 @@
       },
       "description": "Points in 2D image coordinates"
     },
+    "outline_color": {
+      "title": "foxglove.Color",
+      "description": "Outline color",
+      "type": "object",
+      "properties": {
+        "r": {
+          "type": "number",
+          "description": "Red value between 0 and 1"
+        },
+        "g": {
+          "type": "number",
+          "description": "Green value between 0 and 1"
+        },
+        "b": {
+          "type": "number",
+          "description": "Blue value between 0 and 1"
+        },
+        "a": {
+          "type": "number",
+          "description": "Alpha value between 0 and 1"
+        }
+      }
+    },
     "outline_colors": {
       "type": "array",
       "items": {
@@ -90,7 +113,7 @@
           }
         }
       },
-      "description": "Outline colors"
+      "description": "Per-point colors, if `type` is `POINTS`, or per-segment stroke colors, if `type` is `LINE_LIST`."
     },
     "fill_color": {
       "title": "foxglove.Color",
@@ -114,6 +137,10 @@
           "description": "Alpha value between 0 and 1"
         }
       }
+    },
+    "thickness": {
+      "type": "number",
+      "description": "Stroke thickness"
     }
   }
 }

--- a/schemas/proto/foxglove/PointsAnnotation.proto
+++ b/schemas/proto/foxglove/PointsAnnotation.proto
@@ -31,9 +31,15 @@ message PointsAnnotation {
   // Points in 2D image coordinates
   repeated foxglove.Point2 points = 3;
 
-  // Outline colors
-  repeated foxglove.Color outline_colors = 4;
+  // Outline color
+  foxglove.Color outline_color = 4;
+
+  // Per-point colors, if `type` is `POINTS`, or per-segment stroke colors, if `type` is `LINE_LIST`.
+  repeated foxglove.Color outline_colors = 5;
 
   // Fill color
-  foxglove.Color fill_color = 5;
+  foxglove.Color fill_color = 6;
+
+  // Stroke thickness
+  double thickness = 7;
 }

--- a/schemas/ros1/PointsAnnotation.msg
+++ b/schemas/ros1/PointsAnnotation.msg
@@ -18,8 +18,14 @@ uint8 type
 # Points in 2D image coordinates
 foxglove_msgs/Point2[] points
 
-# Outline colors
+# Outline color
+foxglove_msgs/Color outline_color
+
+# Per-point colors, if `type` is `POINTS`, or per-segment stroke colors, if `type` is `LINE_LIST`.
 foxglove_msgs/Color[] outline_colors
 
 # Fill color
 foxglove_msgs/Color fill_color
+
+# Stroke thickness
+float64 thickness

--- a/schemas/ros2/PointsAnnotation.msg
+++ b/schemas/ros2/PointsAnnotation.msg
@@ -18,8 +18,14 @@ uint8 type
 # Points in 2D image coordinates
 foxglove_msgs/Point2[] points
 
-# Outline colors
+# Outline color
+foxglove_msgs/Color outline_color
+
+# Per-point colors, if `type` is `POINTS`, or per-segment stroke colors, if `type` is `LINE_LIST`.
 foxglove_msgs/Color[] outline_colors
 
 # Fill color
 foxglove_msgs/Color fill_color
+
+# Stroke thickness
+float64 thickness

--- a/schemas/typescript/PointsAnnotation.ts
+++ b/schemas/typescript/PointsAnnotation.ts
@@ -16,9 +16,15 @@ export type PointsAnnotation = {
   /** Points in 2D image coordinates */
   points: Point2[];
 
-  /** Outline colors */
+  /** Outline color */
+  outline_color: Color;
+
+  /** Per-point colors, if `type` is `POINTS`, or per-segment stroke colors, if `type` is `LINE_LIST`. */
   outline_colors: Color[];
 
   /** Fill color */
   fill_color: Color;
+
+  /** Stroke thickness */
+  thickness: number;
 };

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -576,15 +576,26 @@ const foxglove_PointsAnnotation: FoxgloveMessageSchema = {
       array: true,
     },
     {
+      name: "outline_color",
+      type: { type: "nested", schema: foxglove_Color },
+      description: "Outline color",
+    },
+    {
       name: "outline_colors",
       type: { type: "nested", schema: foxglove_Color },
-      description: "Outline colors",
+      description:
+        "Per-point colors, if `type` is `POINTS`, or per-segment stroke colors, if `type` is `LINE_LIST`.",
       array: true,
     },
     {
       name: "fill_color",
       type: { type: "nested", schema: foxglove_Color },
       description: "Fill color",
+    },
+    {
+      name: "thickness",
+      type: { type: "primitive", name: "float64" },
+      description: "Stroke thickness",
     },
   ],
 };


### PR DESCRIPTION
**Public-Facing Changes**
Added missing documentation for PointsAnnotation `outline_color` and `thickness` fields

**Description**
Foxglove Studio depended on the values of these fields, but they were not documented.

Relates to https://github.com/foxglove/studio/issues/4080