### PR TITLE
Add docs links for certain schema field descriptions

### DIFF
--- a/schemas/README.md
+++ b/schemas/README.md
@@ -154,7 +154,7 @@ string
 </td>
 <td>
 
-Name of distortion model
+<a href="https://foxglove.dev/docs/studio/panels/image#cameracalibration">Name of distortion model</a>
 
 </td>
 </tr>
@@ -449,7 +449,7 @@ string
 </td>
 <td>
 
-Image format
+<a href="https://foxglove.dev/docs/studio/panels/image#supported-encoding-formats">Image format</a>
 
 </td>
 </tr>
@@ -1589,7 +1589,7 @@ string
 </td>
 <td>
 
-Encoding of the raw image data
+<a href="https://foxglove.dev/docs/studio/panels/image#supported-encoding-formats">Encoding of the raw image data</a>
 
 </td>
 </tr>

--- a/src/generateMarkdown.ts
+++ b/src/generateMarkdown.ts
@@ -74,7 +74,7 @@ ${type}${arraySuffix}
 </td>
 <td>
 
-${field.description}
+${field.docsLink ? `<a href="${field.docsLink}">${field.description}</a>` : field.description}
 
 </td>
 </tr>`;

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -184,6 +184,7 @@ const foxglove_CameraCalibration: FoxgloveMessageSchema = {
       name: "distortion_model",
       type: { type: "primitive", name: "string" },
       description: "Name of distortion model",
+      docsLink: "https://foxglove.dev/docs/studio/panels/image#cameracalibration",
     },
     {
       name: "D",

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -270,6 +270,7 @@ const foxglove_CompressedImage: FoxgloveMessageSchema = {
       name: "format",
       type: { type: "primitive", name: "string" },
       description: "Image format",
+      docsLink: "https://foxglove.dev/docs/studio/panels/image#supported-encoding-formats",
     },
   ],
 };
@@ -298,6 +299,7 @@ const foxglove_RawImage: FoxgloveMessageSchema = {
       name: "encoding",
       type: { type: "primitive", name: "string" },
       description: "Encoding of the raw image data",
+      docsLink: "https://foxglove.dev/docs/studio/panels/image#supported-encoding-formats",
     },
     {
       name: "step",

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,6 +34,7 @@ export type FoxgloveMessageSchema = {
     array?: true | number;
     required?: true;
     description: string;
+    docsLink?: string;
   }>;
 };
 


### PR DESCRIPTION
**Public-Facing Changes**
<!-- describe any changes to the public interface or APIs, or write "None" -->
- Added link to Foxglove Studio docs for `CameraCalibration` schema field description 
- Added link to Foxglove Studio docs for `RawImage` and `CompressedImage` schema field descriptions

