### PR TITLE
Generate bazel build rules for proto schemas

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,17 @@
+workspace(name = "com_github_foxglove_schemas")
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "com_google_protobuf",
+    sha256 = "dbb16fdbca8f277c9a194d9a837395cde408ca136738d94743130dd0de015efd",
+    strip_prefix = "protobuf-21.6",
+    urls = [
+        "https://mirror.bazel.build/github.com/protocolbuffers/protobuf/archive/refs/tags/v21.6.tar.gz",
+        "https://github.com/protocolbuffers/protobuf/archive/refs/tags/v21.6.tar.gz",
+    ],
+)
+
+load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+
+protobuf_deps()

--- a/proto/BUILD.bazel
+++ b/proto/BUILD.bazel
@@ -1,0 +1,3 @@
+# gazelle:proto_strip_import_prefix /proto
+# gazelle:proto file
+# gazelle:go_generate_proto false

--- a/proto/foxglove/BUILD.bazel
+++ b/proto/foxglove/BUILD.bazel
@@ -1,0 +1,54 @@
+load("@rules_cc//cc:defs.bzl", "cc_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
+proto_library(
+    name = "CompressedImage_proto",
+    srcs = ["CompressedImage.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+)
+
+cc_proto_library(
+    name = "CompressedImage_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":CompressedImage_proto"],
+)
+
+proto_library(
+    name = "LocationFix_proto",
+    srcs = ["LocationFix.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+)
+
+cc_proto_library(
+    name = "LocationFix_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":LocationFix_proto"],
+)
+
+proto_library(
+    name = "Log_proto",
+    srcs = ["Log.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+)
+
+cc_proto_library(
+    name = "Log_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":Log_proto"],
+)
+
+proto_library(
+    name = "RawImage_proto",
+    srcs = ["RawImage.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+)
+
+cc_proto_library(
+    name = "RawImage_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":RawImage_proto"],
+)

--- a/proto/foxglove/Log.proto
+++ b/proto/foxglove/Log.proto
@@ -8,6 +8,7 @@ message Log {
   uint64 timestamp = 1;
 
   enum LogLevel {
+    UNKNOWN = 0;
     DEBUG = 1;
     INFO = 2;
     WARN = 3;

--- a/proto/ros/BUILD.bazel
+++ b/proto/ros/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@rules_cc//cc:defs.bzl", "cc_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
+proto_library(
+    name = "builtins_proto",
+    srcs = ["builtins.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+)
+
+cc_proto_library(
+    name = "builtins_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":builtins_proto"],
+)

--- a/proto/ros/actionlib_msgs/BUILD.bazel
+++ b/proto/ros/actionlib_msgs/BUILD.bazel
@@ -1,0 +1,47 @@
+load("@rules_cc//cc:defs.bzl", "cc_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
+proto_library(
+    name = "GoalID_proto",
+    srcs = ["GoalID.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+    deps = ["//proto/ros:builtins_proto"],
+)
+
+cc_proto_library(
+    name = "GoalID_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":GoalID_proto"],
+)
+
+proto_library(
+    name = "GoalStatusArray_proto",
+    srcs = ["GoalStatusArray.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":GoalStatus_proto",
+        "//proto/ros/std_msgs:Header_proto",
+    ],
+)
+
+cc_proto_library(
+    name = "GoalStatusArray_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":GoalStatusArray_proto"],
+)
+
+proto_library(
+    name = "GoalStatus_proto",
+    srcs = ["GoalStatus.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+    deps = [":GoalID_proto"],
+)
+
+cc_proto_library(
+    name = "GoalStatus_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":GoalStatus_proto"],
+)

--- a/proto/ros/diagnostic_msgs/BUILD.bazel
+++ b/proto/ros/diagnostic_msgs/BUILD.bazel
@@ -1,0 +1,46 @@
+load("@rules_cc//cc:defs.bzl", "cc_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
+proto_library(
+    name = "DiagnosticArray_proto",
+    srcs = ["DiagnosticArray.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":DiagnosticStatus_proto",
+        "//proto/ros/std_msgs:Header_proto",
+    ],
+)
+
+cc_proto_library(
+    name = "DiagnosticArray_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":DiagnosticArray_proto"],
+)
+
+proto_library(
+    name = "DiagnosticStatus_proto",
+    srcs = ["DiagnosticStatus.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+    deps = [":KeyValue_proto"],
+)
+
+cc_proto_library(
+    name = "DiagnosticStatus_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":DiagnosticStatus_proto"],
+)
+
+proto_library(
+    name = "KeyValue_proto",
+    srcs = ["KeyValue.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+)
+
+cc_proto_library(
+    name = "KeyValue_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":KeyValue_proto"],
+)

--- a/proto/ros/foxglove_msgs/BUILD.bazel
+++ b/proto/ros/foxglove_msgs/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@rules_cc//cc:defs.bzl", "cc_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
+proto_library(
+    name = "ImageMarkerArray_proto",
+    srcs = ["ImageMarkerArray.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+    deps = ["//proto/ros/visualization_msgs:ImageMarker_proto"],
+)
+
+cc_proto_library(
+    name = "ImageMarkerArray_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":ImageMarkerArray_proto"],
+)

--- a/proto/ros/geometry_msgs/BUILD.bazel
+++ b/proto/ros/geometry_msgs/BUILD.bazel
@@ -1,0 +1,438 @@
+load("@rules_cc//cc:defs.bzl", "cc_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
+proto_library(
+    name = "AccelStamped_proto",
+    srcs = ["AccelStamped.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":Accel_proto",
+        "//proto/ros/std_msgs:Header_proto",
+    ],
+)
+
+cc_proto_library(
+    name = "AccelStamped_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":AccelStamped_proto"],
+)
+
+proto_library(
+    name = "AccelWithCovarianceStamped_proto",
+    srcs = ["AccelWithCovarianceStamped.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":AccelWithCovariance_proto",
+        "//proto/ros/std_msgs:Header_proto",
+    ],
+)
+
+cc_proto_library(
+    name = "AccelWithCovarianceStamped_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":AccelWithCovarianceStamped_proto"],
+)
+
+proto_library(
+    name = "AccelWithCovariance_proto",
+    srcs = ["AccelWithCovariance.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+    deps = [":Accel_proto"],
+)
+
+cc_proto_library(
+    name = "AccelWithCovariance_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":AccelWithCovariance_proto"],
+)
+
+proto_library(
+    name = "Accel_proto",
+    srcs = ["Accel.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+    deps = [":Vector3_proto"],
+)
+
+cc_proto_library(
+    name = "Accel_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":Accel_proto"],
+)
+
+proto_library(
+    name = "InertiaStamped_proto",
+    srcs = ["InertiaStamped.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":Inertia_proto",
+        "//proto/ros/std_msgs:Header_proto",
+    ],
+)
+
+cc_proto_library(
+    name = "InertiaStamped_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":InertiaStamped_proto"],
+)
+
+proto_library(
+    name = "Inertia_proto",
+    srcs = ["Inertia.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+    deps = [":Vector3_proto"],
+)
+
+cc_proto_library(
+    name = "Inertia_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":Inertia_proto"],
+)
+
+proto_library(
+    name = "Point32_proto",
+    srcs = ["Point32.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+)
+
+cc_proto_library(
+    name = "Point32_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":Point32_proto"],
+)
+
+proto_library(
+    name = "PointStamped_proto",
+    srcs = ["PointStamped.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":Point_proto",
+        "//proto/ros/std_msgs:Header_proto",
+    ],
+)
+
+cc_proto_library(
+    name = "PointStamped_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":PointStamped_proto"],
+)
+
+proto_library(
+    name = "Point_proto",
+    srcs = ["Point.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+)
+
+cc_proto_library(
+    name = "Point_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":Point_proto"],
+)
+
+proto_library(
+    name = "PolygonStamped_proto",
+    srcs = ["PolygonStamped.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":Polygon_proto",
+        "//proto/ros/std_msgs:Header_proto",
+    ],
+)
+
+cc_proto_library(
+    name = "PolygonStamped_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":PolygonStamped_proto"],
+)
+
+proto_library(
+    name = "Polygon_proto",
+    srcs = ["Polygon.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+    deps = [":Point32_proto"],
+)
+
+cc_proto_library(
+    name = "Polygon_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":Polygon_proto"],
+)
+
+proto_library(
+    name = "PoseArray_proto",
+    srcs = ["PoseArray.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":Pose_proto",
+        "//proto/ros/std_msgs:Header_proto",
+    ],
+)
+
+cc_proto_library(
+    name = "PoseArray_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":PoseArray_proto"],
+)
+
+proto_library(
+    name = "PoseStamped_proto",
+    srcs = ["PoseStamped.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":Pose_proto",
+        "//proto/ros/std_msgs:Header_proto",
+    ],
+)
+
+cc_proto_library(
+    name = "PoseStamped_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":PoseStamped_proto"],
+)
+
+proto_library(
+    name = "PoseWithCovarianceStamped_proto",
+    srcs = ["PoseWithCovarianceStamped.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":PoseWithCovariance_proto",
+        "//proto/ros/std_msgs:Header_proto",
+    ],
+)
+
+cc_proto_library(
+    name = "PoseWithCovarianceStamped_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":PoseWithCovarianceStamped_proto"],
+)
+
+proto_library(
+    name = "PoseWithCovariance_proto",
+    srcs = ["PoseWithCovariance.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+    deps = [":Pose_proto"],
+)
+
+cc_proto_library(
+    name = "PoseWithCovariance_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":PoseWithCovariance_proto"],
+)
+
+proto_library(
+    name = "Pose_proto",
+    srcs = ["Pose.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":Point_proto",
+        ":Quaternion_proto",
+    ],
+)
+
+cc_proto_library(
+    name = "Pose_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":Pose_proto"],
+)
+
+proto_library(
+    name = "QuaternionStamped_proto",
+    srcs = ["QuaternionStamped.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":Quaternion_proto",
+        "//proto/ros/std_msgs:Header_proto",
+    ],
+)
+
+cc_proto_library(
+    name = "QuaternionStamped_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":QuaternionStamped_proto"],
+)
+
+proto_library(
+    name = "Quaternion_proto",
+    srcs = ["Quaternion.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+)
+
+cc_proto_library(
+    name = "Quaternion_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":Quaternion_proto"],
+)
+
+proto_library(
+    name = "TransformStamped_proto",
+    srcs = ["TransformStamped.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":Transform_proto",
+        "//proto/ros/std_msgs:Header_proto",
+    ],
+)
+
+cc_proto_library(
+    name = "TransformStamped_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":TransformStamped_proto"],
+)
+
+proto_library(
+    name = "Transform_proto",
+    srcs = ["Transform.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":Quaternion_proto",
+        ":Vector3_proto",
+    ],
+)
+
+cc_proto_library(
+    name = "Transform_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":Transform_proto"],
+)
+
+proto_library(
+    name = "TwistStamped_proto",
+    srcs = ["TwistStamped.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":Twist_proto",
+        "//proto/ros/std_msgs:Header_proto",
+    ],
+)
+
+cc_proto_library(
+    name = "TwistStamped_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":TwistStamped_proto"],
+)
+
+proto_library(
+    name = "TwistWithCovarianceStamped_proto",
+    srcs = ["TwistWithCovarianceStamped.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":TwistWithCovariance_proto",
+        "//proto/ros/std_msgs:Header_proto",
+    ],
+)
+
+cc_proto_library(
+    name = "TwistWithCovarianceStamped_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":TwistWithCovarianceStamped_proto"],
+)
+
+proto_library(
+    name = "TwistWithCovariance_proto",
+    srcs = ["TwistWithCovariance.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+    deps = [":Twist_proto"],
+)
+
+cc_proto_library(
+    name = "TwistWithCovariance_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":TwistWithCovariance_proto"],
+)
+
+proto_library(
+    name = "Twist_proto",
+    srcs = ["Twist.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+    deps = [":Vector3_proto"],
+)
+
+cc_proto_library(
+    name = "Twist_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":Twist_proto"],
+)
+
+proto_library(
+    name = "Vector3Stamped_proto",
+    srcs = ["Vector3Stamped.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":Vector3_proto",
+        "//proto/ros/std_msgs:Header_proto",
+    ],
+)
+
+cc_proto_library(
+    name = "Vector3Stamped_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":Vector3Stamped_proto"],
+)
+
+proto_library(
+    name = "Vector3_proto",
+    srcs = ["Vector3.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+)
+
+cc_proto_library(
+    name = "Vector3_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":Vector3_proto"],
+)
+
+proto_library(
+    name = "WrenchStamped_proto",
+    srcs = ["WrenchStamped.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":Wrench_proto",
+        "//proto/ros/std_msgs:Header_proto",
+    ],
+)
+
+cc_proto_library(
+    name = "WrenchStamped_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":WrenchStamped_proto"],
+)
+
+proto_library(
+    name = "Wrench_proto",
+    srcs = ["Wrench.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+    deps = [":Vector3_proto"],
+)
+
+cc_proto_library(
+    name = "Wrench_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":Wrench_proto"],
+)

--- a/proto/ros/nav_msgs/BUILD.bazel
+++ b/proto/ros/nav_msgs/BUILD.bazel
@@ -1,0 +1,71 @@
+load("@rules_cc//cc:defs.bzl", "cc_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
+proto_library(
+    name = "MapMetaData_proto",
+    srcs = ["MapMetaData.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//proto/ros:builtins_proto",
+        "//proto/ros/geometry_msgs:Pose_proto",
+    ],
+)
+
+cc_proto_library(
+    name = "MapMetaData_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":MapMetaData_proto"],
+)
+
+proto_library(
+    name = "OccupancyGrid_proto",
+    srcs = ["OccupancyGrid.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":MapMetaData_proto",
+        "//proto/ros/std_msgs:Header_proto",
+    ],
+)
+
+cc_proto_library(
+    name = "OccupancyGrid_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":OccupancyGrid_proto"],
+)
+
+proto_library(
+    name = "Odometry_proto",
+    srcs = ["Odometry.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//proto/ros/geometry_msgs:PoseWithCovariance_proto",
+        "//proto/ros/geometry_msgs:TwistWithCovariance_proto",
+        "//proto/ros/std_msgs:Header_proto",
+    ],
+)
+
+cc_proto_library(
+    name = "Odometry_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":Odometry_proto"],
+)
+
+proto_library(
+    name = "Path_proto",
+    srcs = ["Path.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//proto/ros/geometry_msgs:PoseStamped_proto",
+        "//proto/ros/std_msgs:Header_proto",
+    ],
+)
+
+cc_proto_library(
+    name = "Path_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":Path_proto"],
+)

--- a/proto/ros/rcl_interfaces/BUILD.bazel
+++ b/proto/ros/rcl_interfaces/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@rules_cc//cc:defs.bzl", "cc_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
+proto_library(
+    name = "Log_proto",
+    srcs = ["Log.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+    deps = ["//proto/ros:builtins_proto"],
+)
+
+cc_proto_library(
+    name = "Log_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":Log_proto"],
+)

--- a/proto/ros/rosgraph_msgs/BUILD.bazel
+++ b/proto/ros/rosgraph_msgs/BUILD.bazel
@@ -1,0 +1,44 @@
+load("@rules_cc//cc:defs.bzl", "cc_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
+proto_library(
+    name = "Clock_proto",
+    srcs = ["Clock.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+    deps = ["//proto/ros:builtins_proto"],
+)
+
+cc_proto_library(
+    name = "Clock_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":Clock_proto"],
+)
+
+proto_library(
+    name = "Log_proto",
+    srcs = ["Log.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+    deps = ["//proto/ros/std_msgs:Header_proto"],
+)
+
+cc_proto_library(
+    name = "Log_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":Log_proto"],
+)
+
+proto_library(
+    name = "TopicStatistics_proto",
+    srcs = ["TopicStatistics.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+    deps = ["//proto/ros:builtins_proto"],
+)
+
+cc_proto_library(
+    name = "TopicStatistics_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":TopicStatistics_proto"],
+)

--- a/proto/ros/sensor_msgs/BUILD.bazel
+++ b/proto/ros/sensor_msgs/BUILD.bazel
@@ -1,0 +1,374 @@
+load("@rules_cc//cc:defs.bzl", "cc_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
+proto_library(
+    name = "BatteryState_proto",
+    srcs = ["BatteryState.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+    deps = ["//proto/ros/std_msgs:Header_proto"],
+)
+
+cc_proto_library(
+    name = "BatteryState_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":BatteryState_proto"],
+)
+
+proto_library(
+    name = "CameraInfo_proto",
+    srcs = ["CameraInfo.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":RegionOfInterest_proto",
+        "//proto/ros/std_msgs:Header_proto",
+    ],
+)
+
+cc_proto_library(
+    name = "CameraInfo_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":CameraInfo_proto"],
+)
+
+proto_library(
+    name = "CompressedImage_proto",
+    srcs = ["CompressedImage.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+    deps = ["//proto/ros/std_msgs:Header_proto"],
+)
+
+cc_proto_library(
+    name = "CompressedImage_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":CompressedImage_proto"],
+)
+
+proto_library(
+    name = "FluidPressure_proto",
+    srcs = ["FluidPressure.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+    deps = ["//proto/ros/std_msgs:Header_proto"],
+)
+
+cc_proto_library(
+    name = "FluidPressure_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":FluidPressure_proto"],
+)
+
+proto_library(
+    name = "Illuminance_proto",
+    srcs = ["Illuminance.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+    deps = ["//proto/ros/std_msgs:Header_proto"],
+)
+
+cc_proto_library(
+    name = "Illuminance_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":Illuminance_proto"],
+)
+
+proto_library(
+    name = "Image_proto",
+    srcs = ["Image.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+    deps = ["//proto/ros/std_msgs:Header_proto"],
+)
+
+cc_proto_library(
+    name = "Image_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":Image_proto"],
+)
+
+proto_library(
+    name = "Imu_proto",
+    srcs = ["Imu.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//proto/ros/geometry_msgs:Quaternion_proto",
+        "//proto/ros/geometry_msgs:Vector3_proto",
+        "//proto/ros/std_msgs:Header_proto",
+    ],
+)
+
+cc_proto_library(
+    name = "Imu_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":Imu_proto"],
+)
+
+proto_library(
+    name = "JointState_proto",
+    srcs = ["JointState.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+    deps = ["//proto/ros/std_msgs:Header_proto"],
+)
+
+cc_proto_library(
+    name = "JointState_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":JointState_proto"],
+)
+
+proto_library(
+    name = "JoyFeedbackArray_proto",
+    srcs = ["JoyFeedbackArray.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+    deps = [":JoyFeedback_proto"],
+)
+
+cc_proto_library(
+    name = "JoyFeedbackArray_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":JoyFeedbackArray_proto"],
+)
+
+proto_library(
+    name = "JoyFeedback_proto",
+    srcs = ["JoyFeedback.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+)
+
+cc_proto_library(
+    name = "JoyFeedback_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":JoyFeedback_proto"],
+)
+
+proto_library(
+    name = "Joy_proto",
+    srcs = ["Joy.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+    deps = ["//proto/ros/std_msgs:Header_proto"],
+)
+
+cc_proto_library(
+    name = "Joy_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":Joy_proto"],
+)
+
+proto_library(
+    name = "LaserEcho_proto",
+    srcs = ["LaserEcho.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+)
+
+cc_proto_library(
+    name = "LaserEcho_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":LaserEcho_proto"],
+)
+
+proto_library(
+    name = "LaserScan_proto",
+    srcs = ["LaserScan.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+    deps = ["//proto/ros/std_msgs:Header_proto"],
+)
+
+cc_proto_library(
+    name = "LaserScan_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":LaserScan_proto"],
+)
+
+proto_library(
+    name = "MagneticField_proto",
+    srcs = ["MagneticField.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//proto/ros/geometry_msgs:Vector3_proto",
+        "//proto/ros/std_msgs:Header_proto",
+    ],
+)
+
+cc_proto_library(
+    name = "MagneticField_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":MagneticField_proto"],
+)
+
+proto_library(
+    name = "MultiDOFJointState_proto",
+    srcs = ["MultiDOFJointState.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//proto/ros/geometry_msgs:Transform_proto",
+        "//proto/ros/geometry_msgs:Twist_proto",
+        "//proto/ros/geometry_msgs:Wrench_proto",
+        "//proto/ros/std_msgs:Header_proto",
+    ],
+)
+
+cc_proto_library(
+    name = "MultiDOFJointState_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":MultiDOFJointState_proto"],
+)
+
+proto_library(
+    name = "MultiEchoLaserScan_proto",
+    srcs = ["MultiEchoLaserScan.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":LaserEcho_proto",
+        "//proto/ros/std_msgs:Header_proto",
+    ],
+)
+
+cc_proto_library(
+    name = "MultiEchoLaserScan_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":MultiEchoLaserScan_proto"],
+)
+
+proto_library(
+    name = "NavSatFix_proto",
+    srcs = ["NavSatFix.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":NavSatStatus_proto",
+        "//proto/ros/std_msgs:Header_proto",
+    ],
+)
+
+cc_proto_library(
+    name = "NavSatFix_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":NavSatFix_proto"],
+)
+
+proto_library(
+    name = "NavSatStatus_proto",
+    srcs = ["NavSatStatus.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+)
+
+cc_proto_library(
+    name = "NavSatStatus_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":NavSatStatus_proto"],
+)
+
+proto_library(
+    name = "PointCloud2_proto",
+    srcs = ["PointCloud2.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":PointField_proto",
+        "//proto/ros/std_msgs:Header_proto",
+    ],
+)
+
+cc_proto_library(
+    name = "PointCloud2_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":PointCloud2_proto"],
+)
+
+proto_library(
+    name = "PointField_proto",
+    srcs = ["PointField.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+)
+
+cc_proto_library(
+    name = "PointField_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":PointField_proto"],
+)
+
+proto_library(
+    name = "Range_proto",
+    srcs = ["Range.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+    deps = ["//proto/ros/std_msgs:Header_proto"],
+)
+
+cc_proto_library(
+    name = "Range_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":Range_proto"],
+)
+
+proto_library(
+    name = "RegionOfInterest_proto",
+    srcs = ["RegionOfInterest.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+)
+
+cc_proto_library(
+    name = "RegionOfInterest_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":RegionOfInterest_proto"],
+)
+
+proto_library(
+    name = "RelativeHumidity_proto",
+    srcs = ["RelativeHumidity.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+    deps = ["//proto/ros/std_msgs:Header_proto"],
+)
+
+cc_proto_library(
+    name = "RelativeHumidity_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":RelativeHumidity_proto"],
+)
+
+proto_library(
+    name = "Temperature_proto",
+    srcs = ["Temperature.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+    deps = ["//proto/ros/std_msgs:Header_proto"],
+)
+
+cc_proto_library(
+    name = "Temperature_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":Temperature_proto"],
+)
+
+proto_library(
+    name = "TimeReference_proto",
+    srcs = ["TimeReference.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//proto/ros:builtins_proto",
+        "//proto/ros/std_msgs:Header_proto",
+    ],
+)
+
+cc_proto_library(
+    name = "TimeReference_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":TimeReference_proto"],
+)

--- a/proto/ros/shape_msgs/BUILD.bazel
+++ b/proto/ros/shape_msgs/BUILD.bazel
@@ -1,0 +1,58 @@
+load("@rules_cc//cc:defs.bzl", "cc_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
+proto_library(
+    name = "MeshTriangle_proto",
+    srcs = ["MeshTriangle.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+)
+
+cc_proto_library(
+    name = "MeshTriangle_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":MeshTriangle_proto"],
+)
+
+proto_library(
+    name = "Mesh_proto",
+    srcs = ["Mesh.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":MeshTriangle_proto",
+        "//proto/ros/geometry_msgs:Point_proto",
+    ],
+)
+
+cc_proto_library(
+    name = "Mesh_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":Mesh_proto"],
+)
+
+proto_library(
+    name = "Plane_proto",
+    srcs = ["Plane.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+)
+
+cc_proto_library(
+    name = "Plane_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":Plane_proto"],
+)
+
+proto_library(
+    name = "SolidPrimitive_proto",
+    srcs = ["SolidPrimitive.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+)
+
+cc_proto_library(
+    name = "SolidPrimitive_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":SolidPrimitive_proto"],
+)

--- a/proto/ros/std_msgs/BUILD.bazel
+++ b/proto/ros/std_msgs/BUILD.bazel
@@ -1,0 +1,419 @@
+load("@rules_cc//cc:defs.bzl", "cc_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
+proto_library(
+    name = "Bool_proto",
+    srcs = ["Bool.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+)
+
+cc_proto_library(
+    name = "Bool_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":Bool_proto"],
+)
+
+proto_library(
+    name = "ByteMultiArray_proto",
+    srcs = ["ByteMultiArray.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+    deps = [":MultiArrayLayout_proto"],
+)
+
+cc_proto_library(
+    name = "ByteMultiArray_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":ByteMultiArray_proto"],
+)
+
+proto_library(
+    name = "Byte_proto",
+    srcs = ["Byte.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+)
+
+cc_proto_library(
+    name = "Byte_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":Byte_proto"],
+)
+
+proto_library(
+    name = "Char_proto",
+    srcs = ["Char.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+)
+
+cc_proto_library(
+    name = "Char_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":Char_proto"],
+)
+
+proto_library(
+    name = "ColorRGBA_proto",
+    srcs = ["ColorRGBA.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+)
+
+cc_proto_library(
+    name = "ColorRGBA_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":ColorRGBA_proto"],
+)
+
+proto_library(
+    name = "Duration_proto",
+    srcs = ["Duration.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+    deps = ["//proto/ros:builtins_proto"],
+)
+
+cc_proto_library(
+    name = "Duration_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":Duration_proto"],
+)
+
+proto_library(
+    name = "Empty_proto",
+    srcs = ["Empty.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+)
+
+cc_proto_library(
+    name = "Empty_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":Empty_proto"],
+)
+
+proto_library(
+    name = "Float32MultiArray_proto",
+    srcs = ["Float32MultiArray.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+    deps = [":MultiArrayLayout_proto"],
+)
+
+cc_proto_library(
+    name = "Float32MultiArray_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":Float32MultiArray_proto"],
+)
+
+proto_library(
+    name = "Float32_proto",
+    srcs = ["Float32.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+)
+
+cc_proto_library(
+    name = "Float32_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":Float32_proto"],
+)
+
+proto_library(
+    name = "Float64MultiArray_proto",
+    srcs = ["Float64MultiArray.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+    deps = [":MultiArrayLayout_proto"],
+)
+
+cc_proto_library(
+    name = "Float64MultiArray_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":Float64MultiArray_proto"],
+)
+
+proto_library(
+    name = "Float64_proto",
+    srcs = ["Float64.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+)
+
+cc_proto_library(
+    name = "Float64_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":Float64_proto"],
+)
+
+proto_library(
+    name = "Header_proto",
+    srcs = ["Header.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+    deps = ["//proto/ros:builtins_proto"],
+)
+
+cc_proto_library(
+    name = "Header_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":Header_proto"],
+)
+
+proto_library(
+    name = "Int16MultiArray_proto",
+    srcs = ["Int16MultiArray.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+    deps = [":MultiArrayLayout_proto"],
+)
+
+cc_proto_library(
+    name = "Int16MultiArray_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":Int16MultiArray_proto"],
+)
+
+proto_library(
+    name = "Int16_proto",
+    srcs = ["Int16.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+)
+
+cc_proto_library(
+    name = "Int16_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":Int16_proto"],
+)
+
+proto_library(
+    name = "Int32MultiArray_proto",
+    srcs = ["Int32MultiArray.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+    deps = [":MultiArrayLayout_proto"],
+)
+
+cc_proto_library(
+    name = "Int32MultiArray_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":Int32MultiArray_proto"],
+)
+
+proto_library(
+    name = "Int32_proto",
+    srcs = ["Int32.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+)
+
+cc_proto_library(
+    name = "Int32_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":Int32_proto"],
+)
+
+proto_library(
+    name = "Int64MultiArray_proto",
+    srcs = ["Int64MultiArray.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+    deps = [":MultiArrayLayout_proto"],
+)
+
+cc_proto_library(
+    name = "Int64MultiArray_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":Int64MultiArray_proto"],
+)
+
+proto_library(
+    name = "Int64_proto",
+    srcs = ["Int64.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+)
+
+cc_proto_library(
+    name = "Int64_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":Int64_proto"],
+)
+
+proto_library(
+    name = "Int8MultiArray_proto",
+    srcs = ["Int8MultiArray.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+    deps = [":MultiArrayLayout_proto"],
+)
+
+cc_proto_library(
+    name = "Int8MultiArray_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":Int8MultiArray_proto"],
+)
+
+proto_library(
+    name = "Int8_proto",
+    srcs = ["Int8.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+)
+
+cc_proto_library(
+    name = "Int8_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":Int8_proto"],
+)
+
+proto_library(
+    name = "MultiArrayDimension_proto",
+    srcs = ["MultiArrayDimension.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+)
+
+cc_proto_library(
+    name = "MultiArrayDimension_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":MultiArrayDimension_proto"],
+)
+
+proto_library(
+    name = "MultiArrayLayout_proto",
+    srcs = ["MultiArrayLayout.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+    deps = [":MultiArrayDimension_proto"],
+)
+
+cc_proto_library(
+    name = "MultiArrayLayout_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":MultiArrayLayout_proto"],
+)
+
+proto_library(
+    name = "String_proto",
+    srcs = ["String.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+)
+
+cc_proto_library(
+    name = "String_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":String_proto"],
+)
+
+proto_library(
+    name = "Time_proto",
+    srcs = ["Time.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+    deps = ["//proto/ros:builtins_proto"],
+)
+
+cc_proto_library(
+    name = "Time_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":Time_proto"],
+)
+
+proto_library(
+    name = "UInt16MultiArray_proto",
+    srcs = ["UInt16MultiArray.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+    deps = [":MultiArrayLayout_proto"],
+)
+
+cc_proto_library(
+    name = "UInt16MultiArray_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":UInt16MultiArray_proto"],
+)
+
+proto_library(
+    name = "UInt16_proto",
+    srcs = ["UInt16.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+)
+
+cc_proto_library(
+    name = "UInt16_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":UInt16_proto"],
+)
+
+proto_library(
+    name = "UInt32MultiArray_proto",
+    srcs = ["UInt32MultiArray.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+    deps = [":MultiArrayLayout_proto"],
+)
+
+cc_proto_library(
+    name = "UInt32MultiArray_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":UInt32MultiArray_proto"],
+)
+
+proto_library(
+    name = "UInt32_proto",
+    srcs = ["UInt32.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+)
+
+cc_proto_library(
+    name = "UInt32_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":UInt32_proto"],
+)
+
+proto_library(
+    name = "UInt64MultiArray_proto",
+    srcs = ["UInt64MultiArray.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+    deps = [":MultiArrayLayout_proto"],
+)
+
+cc_proto_library(
+    name = "UInt64MultiArray_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":UInt64MultiArray_proto"],
+)
+
+proto_library(
+    name = "UInt64_proto",
+    srcs = ["UInt64.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+)
+
+cc_proto_library(
+    name = "UInt64_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":UInt64_proto"],
+)
+
+proto_library(
+    name = "UInt8_proto",
+    srcs = ["UInt8.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+)
+
+cc_proto_library(
+    name = "UInt8_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":UInt8_proto"],
+)

--- a/proto/ros/stereo_msgs/BUILD.bazel
+++ b/proto/ros/stereo_msgs/BUILD.bazel
@@ -1,0 +1,20 @@
+load("@rules_cc//cc:defs.bzl", "cc_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
+proto_library(
+    name = "DisparityImage_proto",
+    srcs = ["DisparityImage.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//proto/ros/sensor_msgs:Image_proto",
+        "//proto/ros/sensor_msgs:RegionOfInterest_proto",
+        "//proto/ros/std_msgs:Header_proto",
+    ],
+)
+
+cc_proto_library(
+    name = "DisparityImage_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":DisparityImage_proto"],
+)

--- a/proto/ros/tf2_msgs/BUILD.bazel
+++ b/proto/ros/tf2_msgs/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@rules_cc//cc:defs.bzl", "cc_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
+proto_library(
+    name = "TFMessage_proto",
+    srcs = ["TFMessage.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+    deps = ["//proto/ros/geometry_msgs:TransformStamped_proto"],
+)
+
+cc_proto_library(
+    name = "TFMessage_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":TFMessage_proto"],
+)

--- a/proto/ros/trajectory_msgs/BUILD.bazel
+++ b/proto/ros/trajectory_msgs/BUILD.bazel
@@ -1,0 +1,68 @@
+load("@rules_cc//cc:defs.bzl", "cc_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
+proto_library(
+    name = "JointTrajectoryPoint_proto",
+    srcs = ["JointTrajectoryPoint.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+    deps = ["//proto/ros:builtins_proto"],
+)
+
+cc_proto_library(
+    name = "JointTrajectoryPoint_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":JointTrajectoryPoint_proto"],
+)
+
+proto_library(
+    name = "JointTrajectory_proto",
+    srcs = ["JointTrajectory.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":JointTrajectoryPoint_proto",
+        "//proto/ros/std_msgs:Header_proto",
+    ],
+)
+
+cc_proto_library(
+    name = "JointTrajectory_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":JointTrajectory_proto"],
+)
+
+proto_library(
+    name = "MultiDOFJointTrajectoryPoint_proto",
+    srcs = ["MultiDOFJointTrajectoryPoint.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//proto/ros:builtins_proto",
+        "//proto/ros/geometry_msgs:Transform_proto",
+        "//proto/ros/geometry_msgs:Twist_proto",
+    ],
+)
+
+cc_proto_library(
+    name = "MultiDOFJointTrajectoryPoint_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":MultiDOFJointTrajectoryPoint_proto"],
+)
+
+proto_library(
+    name = "MultiDOFJointTrajectory_proto",
+    srcs = ["MultiDOFJointTrajectory.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":MultiDOFJointTrajectoryPoint_proto",
+        "//proto/ros/std_msgs:Header_proto",
+    ],
+)
+
+cc_proto_library(
+    name = "MultiDOFJointTrajectory_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":MultiDOFJointTrajectory_proto"],
+)

--- a/proto/ros/visualization_msgs/BUILD.bazel
+++ b/proto/ros/visualization_msgs/BUILD.bazel
@@ -1,0 +1,105 @@
+load("@rules_cc//cc:defs.bzl", "cc_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
+proto_library(
+    name = "ImageMarker_proto",
+    srcs = ["ImageMarker.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//proto/ros:builtins_proto",
+        "//proto/ros/geometry_msgs:Point_proto",
+        "//proto/ros/std_msgs:ColorRGBA_proto",
+        "//proto/ros/std_msgs:Header_proto",
+    ],
+)
+
+cc_proto_library(
+    name = "ImageMarker_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":ImageMarker_proto"],
+)
+
+proto_library(
+    name = "InteractiveMarkerControl_proto",
+    srcs = ["InteractiveMarkerControl.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":Marker_proto",
+        "//proto/ros/geometry_msgs:Quaternion_proto",
+    ],
+)
+
+cc_proto_library(
+    name = "InteractiveMarkerControl_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":InteractiveMarkerControl_proto"],
+)
+
+proto_library(
+    name = "InteractiveMarker_proto",
+    srcs = ["InteractiveMarker.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":InteractiveMarkerControl_proto",
+        ":MenuEntry_proto",
+        "//proto/ros/geometry_msgs:Pose_proto",
+        "//proto/ros/std_msgs:Header_proto",
+    ],
+)
+
+cc_proto_library(
+    name = "InteractiveMarker_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":InteractiveMarker_proto"],
+)
+
+proto_library(
+    name = "MarkerArray_proto",
+    srcs = ["MarkerArray.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+    deps = [":Marker_proto"],
+)
+
+cc_proto_library(
+    name = "MarkerArray_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":MarkerArray_proto"],
+)
+
+proto_library(
+    name = "Marker_proto",
+    srcs = ["Marker.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//proto/ros:builtins_proto",
+        "//proto/ros/geometry_msgs:Point_proto",
+        "//proto/ros/geometry_msgs:Pose_proto",
+        "//proto/ros/geometry_msgs:Vector3_proto",
+        "//proto/ros/std_msgs:ColorRGBA_proto",
+        "//proto/ros/std_msgs:Header_proto",
+    ],
+)
+
+cc_proto_library(
+    name = "Marker_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":Marker_proto"],
+)
+
+proto_library(
+    name = "MenuEntry_proto",
+    srcs = ["MenuEntry.proto"],
+    strip_import_prefix = "/proto",
+    visibility = ["//visibility:public"],
+)
+
+cc_proto_library(
+    name = "MenuEntry_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":MenuEntry_proto"],
+)

--- a/scripts/buildozer.py
+++ b/scripts/buildozer.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+
+import subprocess
+
+query = subprocess.run(
+    ['bazel', 'query', 'kind("proto_library", //...)'],
+    capture_output=True,
+    text=True,
+    check=True)
+proto_labels = frozenset(path for path in query.stdout.split())
+
+for label in proto_labels:
+    pkg, _, proto_rule = label.rpartition(':')
+    assert proto_rule.endswith('_proto')
+    proto_name = proto_rule[:-6]
+    proto_cc_rule = proto_name + "_cc_proto"
+
+    print(f"new cc_proto_library {proto_cc_rule} after {proto_rule}|{pkg}:__pkg__")
+    print(f"add deps {pkg}:{proto_rule}|{pkg}:{proto_cc_rule}")
+    print(f"set visibility //visibility:public|{pkg}:{proto_cc_rule}")


### PR DESCRIPTION
Auto-generate bazel build rules for proto schemas using gazelle and buildozer.

Also added missing zero enum value for LogLevel