### PR TITLE
Add documentation about supported field values for image-related topics

### DIFF
--- a/internal/schemas.ts
+++ b/internal/schemas.ts
@@ -679,7 +679,7 @@ const CameraCalibration: FoxgloveMessageSchema = {
       name: "distortion_model",
       type: { type: "primitive", name: "string" },
       description:
-        "Name of distortion model\n\nValues supported by Foxglove Studio: `plumb_bob` and `rational_polynomial`",
+        "Name of distortion model\n\nSupported values: `plumb_bob` and `rational_polynomial`",
     },
     {
       name: "D",
@@ -771,7 +771,7 @@ const CompressedImage: FoxgloveMessageSchema = {
     {
       name: "format",
       type: { type: "primitive", name: "string" },
-      description: "Image format\n\nValues supported by Foxglove Studio: `webp`, `jpeg`, `png`",
+      description: "Image format\n\nSupported values: `webp`, `jpeg`, `png`",
     },
   ],
 };
@@ -807,7 +807,7 @@ const RawImage: FoxgloveMessageSchema = {
       name: "encoding",
       type: { type: "primitive", name: "string" },
       description:
-        "Encoding of the raw image data\n\nValues supported by Foxglove Studio: `8UC1`, `8UC3`, `16UC1`, `32FC1`, `bayer_bggr8`, `bayer_gbrg8`, `bayer_grbg8`, `bayer_rggb8`, `bgr8`, `bgra8`, `mono8`, `mono16`, `rgb8`, `rgba8`, `yuv422`",
+        "Encoding of the raw image data\n\nSupported values: `8UC1`, `8UC3`, `16UC1`, `32FC1`, `bayer_bggr8`, `bayer_gbrg8`, `bayer_grbg8`, `bayer_rggb8`, `bgr8`, `bgra8`, `mono8`, `mono16`, `rgb8`, `rgba8`, `yuv422`",
     },
     {
       name: "step",

--- a/internal/schemas.ts
+++ b/internal/schemas.ts
@@ -678,7 +678,8 @@ const CameraCalibration: FoxgloveMessageSchema = {
     {
       name: "distortion_model",
       type: { type: "primitive", name: "string" },
-      description: "Name of distortion model",
+      description:
+        "Name of distortion model\n\nValues supported by Foxglove Studio: `plumb_bob` and `rational_polynomial`",
     },
     {
       name: "D",
@@ -770,7 +771,7 @@ const CompressedImage: FoxgloveMessageSchema = {
     {
       name: "format",
       type: { type: "primitive", name: "string" },
-      description: "Image format",
+      description: "Image format\n\nValues supported by Foxglove Studio: `webp`, `jpeg`, `png`",
     },
   ],
 };
@@ -805,7 +806,8 @@ const RawImage: FoxgloveMessageSchema = {
     {
       name: "encoding",
       type: { type: "primitive", name: "string" },
-      description: "Encoding of the raw image data",
+      description:
+        "Encoding of the raw image data\n\nValues supported by Foxglove Studio: `8UC1`, `8UC3`, `16UC1`, `32FC1`, `bayer_bggr8`, `bayer_gbrg8`, `bayer_grbg8`, `bayer_rggb8`, `bgr8`, `bgra8`, `mono8`, `mono16`, `rgb8`, `rgba8`, `yuv422`",
     },
     {
       name: "step",

--- a/ros_foxglove_msgs/ros1/CameraCalibration.msg
+++ b/ros_foxglove_msgs/ros1/CameraCalibration.msg
@@ -17,7 +17,7 @@ uint32 height
 
 # Name of distortion model
 # 
-# Values supported by Foxglove Studio: `plumb_bob` and `rational_polynomial`
+# Supported values: `plumb_bob` and `rational_polynomial`
 string distortion_model
 
 # Distortion parameters

--- a/ros_foxglove_msgs/ros1/CameraCalibration.msg
+++ b/ros_foxglove_msgs/ros1/CameraCalibration.msg
@@ -16,6 +16,8 @@ uint32 width
 uint32 height
 
 # Name of distortion model
+# 
+# Values supported by Foxglove Studio: `plumb_bob` and `rational_polynomial`
 string distortion_model
 
 # Distortion parameters

--- a/ros_foxglove_msgs/ros1/CompressedImage.msg
+++ b/ros_foxglove_msgs/ros1/CompressedImage.msg
@@ -13,4 +13,6 @@ string frame_id
 uint8[] data
 
 # Image format
+# 
+# Values supported by Foxglove Studio: `webp`, `jpeg`, `png`
 string format

--- a/ros_foxglove_msgs/ros1/CompressedImage.msg
+++ b/ros_foxglove_msgs/ros1/CompressedImage.msg
@@ -14,5 +14,5 @@ uint8[] data
 
 # Image format
 # 
-# Values supported by Foxglove Studio: `webp`, `jpeg`, `png`
+# Supported values: `webp`, `jpeg`, `png`
 string format

--- a/ros_foxglove_msgs/ros1/RawImage.msg
+++ b/ros_foxglove_msgs/ros1/RawImage.msg
@@ -17,7 +17,7 @@ uint32 height
 
 # Encoding of the raw image data
 # 
-# Values supported by Foxglove Studio: `8UC1`, `8UC3`, `16UC1`, `32FC1`, `bayer_bggr8`, `bayer_gbrg8`, `bayer_grbg8`, `bayer_rggb8`, `bgr8`, `bgra8`, `mono8`, `mono16`, `rgb8`, `rgba8`, `yuv422`
+# Supported values: `8UC1`, `8UC3`, `16UC1`, `32FC1`, `bayer_bggr8`, `bayer_gbrg8`, `bayer_grbg8`, `bayer_rggb8`, `bgr8`, `bgra8`, `mono8`, `mono16`, `rgb8`, `rgba8`, `yuv422`
 string encoding
 
 # Byte length of a single row

--- a/ros_foxglove_msgs/ros1/RawImage.msg
+++ b/ros_foxglove_msgs/ros1/RawImage.msg
@@ -16,6 +16,8 @@ uint32 width
 uint32 height
 
 # Encoding of the raw image data
+# 
+# Values supported by Foxglove Studio: `8UC1`, `8UC3`, `16UC1`, `32FC1`, `bayer_bggr8`, `bayer_gbrg8`, `bayer_grbg8`, `bayer_rggb8`, `bgr8`, `bgra8`, `mono8`, `mono16`, `rgb8`, `rgba8`, `yuv422`
 string encoding
 
 # Byte length of a single row

--- a/ros_foxglove_msgs/ros2/CameraCalibration.msg
+++ b/ros_foxglove_msgs/ros2/CameraCalibration.msg
@@ -17,7 +17,7 @@ uint32 height
 
 # Name of distortion model
 # 
-# Values supported by Foxglove Studio: `plumb_bob` and `rational_polynomial`
+# Supported values: `plumb_bob` and `rational_polynomial`
 string distortion_model
 
 # Distortion parameters

--- a/ros_foxglove_msgs/ros2/CameraCalibration.msg
+++ b/ros_foxglove_msgs/ros2/CameraCalibration.msg
@@ -16,6 +16,8 @@ uint32 width
 uint32 height
 
 # Name of distortion model
+# 
+# Values supported by Foxglove Studio: `plumb_bob` and `rational_polynomial`
 string distortion_model
 
 # Distortion parameters

--- a/ros_foxglove_msgs/ros2/CompressedImage.msg
+++ b/ros_foxglove_msgs/ros2/CompressedImage.msg
@@ -13,4 +13,6 @@ string frame_id
 uint8[] data
 
 # Image format
+# 
+# Values supported by Foxglove Studio: `webp`, `jpeg`, `png`
 string format

--- a/ros_foxglove_msgs/ros2/CompressedImage.msg
+++ b/ros_foxglove_msgs/ros2/CompressedImage.msg
@@ -14,5 +14,5 @@ uint8[] data
 
 # Image format
 # 
-# Values supported by Foxglove Studio: `webp`, `jpeg`, `png`
+# Supported values: `webp`, `jpeg`, `png`
 string format

--- a/ros_foxglove_msgs/ros2/RawImage.msg
+++ b/ros_foxglove_msgs/ros2/RawImage.msg
@@ -17,7 +17,7 @@ uint32 height
 
 # Encoding of the raw image data
 # 
-# Values supported by Foxglove Studio: `8UC1`, `8UC3`, `16UC1`, `32FC1`, `bayer_bggr8`, `bayer_gbrg8`, `bayer_grbg8`, `bayer_rggb8`, `bgr8`, `bgra8`, `mono8`, `mono16`, `rgb8`, `rgba8`, `yuv422`
+# Supported values: `8UC1`, `8UC3`, `16UC1`, `32FC1`, `bayer_bggr8`, `bayer_gbrg8`, `bayer_grbg8`, `bayer_rggb8`, `bgr8`, `bgra8`, `mono8`, `mono16`, `rgb8`, `rgba8`, `yuv422`
 string encoding
 
 # Byte length of a single row

--- a/ros_foxglove_msgs/ros2/RawImage.msg
+++ b/ros_foxglove_msgs/ros2/RawImage.msg
@@ -16,6 +16,8 @@ uint32 width
 uint32 height
 
 # Encoding of the raw image data
+# 
+# Values supported by Foxglove Studio: `8UC1`, `8UC3`, `16UC1`, `32FC1`, `bayer_bggr8`, `bayer_gbrg8`, `bayer_grbg8`, `bayer_rggb8`, `bgr8`, `bgra8`, `mono8`, `mono16`, `rgb8`, `rgba8`, `yuv422`
 string encoding
 
 # Byte length of a single row

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -296,7 +296,7 @@ string
 
 Name of distortion model
 
-Values supported by Foxglove Studio: `plumb_bob` and `rational_polynomial`
+Supported values: `plumb_bob` and `rational_polynomial`
 
 </td>
 </tr>
@@ -606,7 +606,7 @@ string
 
 Image format
 
-Values supported by Foxglove Studio: `webp`, `jpeg`, `png`
+Supported values: `webp`, `jpeg`, `png`
 
 </td>
 </tr>
@@ -2148,7 +2148,7 @@ string
 
 Encoding of the raw image data
 
-Values supported by Foxglove Studio: `8UC1`, `8UC3`, `16UC1`, `32FC1`, `bayer_bggr8`, `bayer_gbrg8`, `bayer_grbg8`, `bayer_rggb8`, `bgr8`, `bgra8`, `mono8`, `mono16`, `rgb8`, `rgba8`, `yuv422`
+Supported values: `8UC1`, `8UC3`, `16UC1`, `32FC1`, `bayer_bggr8`, `bayer_gbrg8`, `bayer_grbg8`, `bayer_rggb8`, `bgr8`, `bgra8`, `mono8`, `mono16`, `rgb8`, `rgba8`, `yuv422`
 
 </td>
 </tr>

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -296,6 +296,8 @@ string
 
 Name of distortion model
 
+Values supported by Foxglove Studio: `plumb_bob` and `rational_polynomial`
+
 </td>
 </tr>
 <tr>
@@ -603,6 +605,8 @@ string
 <td>
 
 Image format
+
+Values supported by Foxglove Studio: `webp`, `jpeg`, `png`
 
 </td>
 </tr>
@@ -2143,6 +2147,8 @@ string
 <td>
 
 Encoding of the raw image data
+
+Values supported by Foxglove Studio: `8UC1`, `8UC3`, `16UC1`, `32FC1`, `bayer_bggr8`, `bayer_gbrg8`, `bayer_grbg8`, `bayer_rggb8`, `bgr8`, `bgra8`, `mono8`, `mono16`, `rgb8`, `rgba8`, `yuv422`
 
 </td>
 </tr>

--- a/schemas/jsonschema/CameraCalibration.json
+++ b/schemas/jsonschema/CameraCalibration.json
@@ -36,7 +36,7 @@
     },
     "distortion_model": {
       "type": "string",
-      "description": "Name of distortion model\n\nValues supported by Foxglove Studio: `plumb_bob` and `rational_polynomial`"
+      "description": "Name of distortion model\n\nSupported values: `plumb_bob` and `rational_polynomial`"
     },
     "D": {
       "type": "array",

--- a/schemas/jsonschema/CameraCalibration.json
+++ b/schemas/jsonschema/CameraCalibration.json
@@ -36,7 +36,7 @@
     },
     "distortion_model": {
       "type": "string",
-      "description": "Name of distortion model"
+      "description": "Name of distortion model\n\nValues supported by Foxglove Studio: `plumb_bob` and `rational_polynomial`"
     },
     "D": {
       "type": "array",

--- a/schemas/jsonschema/CompressedImage.json
+++ b/schemas/jsonschema/CompressedImage.json
@@ -31,7 +31,7 @@
     },
     "format": {
       "type": "string",
-      "description": "Image format\n\nValues supported by Foxglove Studio: `webp`, `jpeg`, `png`"
+      "description": "Image format\n\nSupported values: `webp`, `jpeg`, `png`"
     }
   }
 }

--- a/schemas/jsonschema/CompressedImage.json
+++ b/schemas/jsonschema/CompressedImage.json
@@ -31,7 +31,7 @@
     },
     "format": {
       "type": "string",
-      "description": "Image format"
+      "description": "Image format\n\nValues supported by Foxglove Studio: `webp`, `jpeg`, `png`"
     }
   }
 }

--- a/schemas/jsonschema/RawImage.json
+++ b/schemas/jsonschema/RawImage.json
@@ -36,7 +36,7 @@
     },
     "encoding": {
       "type": "string",
-      "description": "Encoding of the raw image data\n\nValues supported by Foxglove Studio: `8UC1`, `8UC3`, `16UC1`, `32FC1`, `bayer_bggr8`, `bayer_gbrg8`, `bayer_grbg8`, `bayer_rggb8`, `bgr8`, `bgra8`, `mono8`, `mono16`, `rgb8`, `rgba8`, `yuv422`"
+      "description": "Encoding of the raw image data\n\nSupported values: `8UC1`, `8UC3`, `16UC1`, `32FC1`, `bayer_bggr8`, `bayer_gbrg8`, `bayer_grbg8`, `bayer_rggb8`, `bgr8`, `bgra8`, `mono8`, `mono16`, `rgb8`, `rgba8`, `yuv422`"
     },
     "step": {
       "type": "integer",

--- a/schemas/jsonschema/RawImage.json
+++ b/schemas/jsonschema/RawImage.json
@@ -36,7 +36,7 @@
     },
     "encoding": {
       "type": "string",
-      "description": "Encoding of the raw image data"
+      "description": "Encoding of the raw image data\n\nValues supported by Foxglove Studio: `8UC1`, `8UC3`, `16UC1`, `32FC1`, `bayer_bggr8`, `bayer_gbrg8`, `bayer_grbg8`, `bayer_rggb8`, `bgr8`, `bgra8`, `mono8`, `mono16`, `rgb8`, `rgba8`, `yuv422`"
     },
     "step": {
       "type": "integer",

--- a/schemas/jsonschema/index.ts
+++ b/schemas/jsonschema/index.ts
@@ -135,7 +135,7 @@ export const CameraCalibration = {
     },
     "distortion_model": {
       "type": "string",
-      "description": "Name of distortion model"
+      "description": "Name of distortion model\n\nValues supported by Foxglove Studio: `plumb_bob` and `rational_polynomial`"
     },
     "D": {
       "type": "array",
@@ -326,7 +326,7 @@ export const CompressedImage = {
     },
     "format": {
       "type": "string",
-      "description": "Image format"
+      "description": "Image format\n\nValues supported by Foxglove Studio: `webp`, `jpeg`, `png`"
     }
   }
 };
@@ -4380,7 +4380,7 @@ export const RawImage = {
     },
     "encoding": {
       "type": "string",
-      "description": "Encoding of the raw image data"
+      "description": "Encoding of the raw image data\n\nValues supported by Foxglove Studio: `8UC1`, `8UC3`, `16UC1`, `32FC1`, `bayer_bggr8`, `bayer_gbrg8`, `bayer_grbg8`, `bayer_rggb8`, `bgr8`, `bgra8`, `mono8`, `mono16`, `rgb8`, `rgba8`, `yuv422`"
     },
     "step": {
       "type": "integer",

--- a/schemas/jsonschema/index.ts
+++ b/schemas/jsonschema/index.ts
@@ -135,7 +135,7 @@ export const CameraCalibration = {
     },
     "distortion_model": {
       "type": "string",
-      "description": "Name of distortion model\n\nValues supported by Foxglove Studio: `plumb_bob` and `rational_polynomial`"
+      "description": "Name of distortion model\n\nSupported values: `plumb_bob` and `rational_polynomial`"
     },
     "D": {
       "type": "array",
@@ -326,7 +326,7 @@ export const CompressedImage = {
     },
     "format": {
       "type": "string",
-      "description": "Image format\n\nValues supported by Foxglove Studio: `webp`, `jpeg`, `png`"
+      "description": "Image format\n\nSupported values: `webp`, `jpeg`, `png`"
     }
   }
 };
@@ -4380,7 +4380,7 @@ export const RawImage = {
     },
     "encoding": {
       "type": "string",
-      "description": "Encoding of the raw image data\n\nValues supported by Foxglove Studio: `8UC1`, `8UC3`, `16UC1`, `32FC1`, `bayer_bggr8`, `bayer_gbrg8`, `bayer_grbg8`, `bayer_rggb8`, `bgr8`, `bgra8`, `mono8`, `mono16`, `rgb8`, `rgba8`, `yuv422`"
+      "description": "Encoding of the raw image data\n\nSupported values: `8UC1`, `8UC3`, `16UC1`, `32FC1`, `bayer_bggr8`, `bayer_gbrg8`, `bayer_grbg8`, `bayer_rggb8`, `bgr8`, `bgra8`, `mono8`, `mono16`, `rgb8`, `rgba8`, `yuv422`"
     },
     "step": {
       "type": "integer",

--- a/schemas/proto/foxglove/CameraCalibration.proto
+++ b/schemas/proto/foxglove/CameraCalibration.proto
@@ -22,7 +22,7 @@ message CameraCalibration {
 
   // Name of distortion model
   // 
-  // Values supported by Foxglove Studio: `plumb_bob` and `rational_polynomial`
+  // Supported values: `plumb_bob` and `rational_polynomial`
   string distortion_model = 4;
 
   // Distortion parameters

--- a/schemas/proto/foxglove/CameraCalibration.proto
+++ b/schemas/proto/foxglove/CameraCalibration.proto
@@ -21,6 +21,8 @@ message CameraCalibration {
   fixed32 height = 3;
 
   // Name of distortion model
+  // 
+  // Values supported by Foxglove Studio: `plumb_bob` and `rational_polynomial`
   string distortion_model = 4;
 
   // Distortion parameters

--- a/schemas/proto/foxglove/CompressedImage.proto
+++ b/schemas/proto/foxglove/CompressedImage.proto
@@ -18,5 +18,7 @@ message CompressedImage {
   bytes data = 2;
 
   // Image format
+  // 
+  // Values supported by Foxglove Studio: `webp`, `jpeg`, `png`
   string format = 3;
 }

--- a/schemas/proto/foxglove/CompressedImage.proto
+++ b/schemas/proto/foxglove/CompressedImage.proto
@@ -19,6 +19,6 @@ message CompressedImage {
 
   // Image format
   // 
-  // Values supported by Foxglove Studio: `webp`, `jpeg`, `png`
+  // Supported values: `webp`, `jpeg`, `png`
   string format = 3;
 }

--- a/schemas/proto/foxglove/RawImage.proto
+++ b/schemas/proto/foxglove/RawImage.proto
@@ -21,6 +21,8 @@ message RawImage {
   fixed32 height = 3;
 
   // Encoding of the raw image data
+  // 
+  // Values supported by Foxglove Studio: `8UC1`, `8UC3`, `16UC1`, `32FC1`, `bayer_bggr8`, `bayer_gbrg8`, `bayer_grbg8`, `bayer_rggb8`, `bgr8`, `bgra8`, `mono8`, `mono16`, `rgb8`, `rgba8`, `yuv422`
   string encoding = 4;
 
   // Byte length of a single row

--- a/schemas/proto/foxglove/RawImage.proto
+++ b/schemas/proto/foxglove/RawImage.proto
@@ -22,7 +22,7 @@ message RawImage {
 
   // Encoding of the raw image data
   // 
-  // Values supported by Foxglove Studio: `8UC1`, `8UC3`, `16UC1`, `32FC1`, `bayer_bggr8`, `bayer_gbrg8`, `bayer_grbg8`, `bayer_rggb8`, `bgr8`, `bgra8`, `mono8`, `mono16`, `rgb8`, `rgba8`, `yuv422`
+  // Supported values: `8UC1`, `8UC3`, `16UC1`, `32FC1`, `bayer_bggr8`, `bayer_gbrg8`, `bayer_grbg8`, `bayer_rggb8`, `bgr8`, `bgra8`, `mono8`, `mono16`, `rgb8`, `rgba8`, `yuv422`
   string encoding = 4;
 
   // Byte length of a single row

--- a/schemas/ros1/CameraCalibration.msg
+++ b/schemas/ros1/CameraCalibration.msg
@@ -17,7 +17,7 @@ uint32 height
 
 # Name of distortion model
 # 
-# Values supported by Foxglove Studio: `plumb_bob` and `rational_polynomial`
+# Supported values: `plumb_bob` and `rational_polynomial`
 string distortion_model
 
 # Distortion parameters

--- a/schemas/ros1/CameraCalibration.msg
+++ b/schemas/ros1/CameraCalibration.msg
@@ -16,6 +16,8 @@ uint32 width
 uint32 height
 
 # Name of distortion model
+# 
+# Values supported by Foxglove Studio: `plumb_bob` and `rational_polynomial`
 string distortion_model
 
 # Distortion parameters

--- a/schemas/ros1/CompressedImage.msg
+++ b/schemas/ros1/CompressedImage.msg
@@ -13,4 +13,6 @@ string frame_id
 uint8[] data
 
 # Image format
+# 
+# Values supported by Foxglove Studio: `webp`, `jpeg`, `png`
 string format

--- a/schemas/ros1/CompressedImage.msg
+++ b/schemas/ros1/CompressedImage.msg
@@ -14,5 +14,5 @@ uint8[] data
 
 # Image format
 # 
-# Values supported by Foxglove Studio: `webp`, `jpeg`, `png`
+# Supported values: `webp`, `jpeg`, `png`
 string format

--- a/schemas/ros1/RawImage.msg
+++ b/schemas/ros1/RawImage.msg
@@ -17,7 +17,7 @@ uint32 height
 
 # Encoding of the raw image data
 # 
-# Values supported by Foxglove Studio: `8UC1`, `8UC3`, `16UC1`, `32FC1`, `bayer_bggr8`, `bayer_gbrg8`, `bayer_grbg8`, `bayer_rggb8`, `bgr8`, `bgra8`, `mono8`, `mono16`, `rgb8`, `rgba8`, `yuv422`
+# Supported values: `8UC1`, `8UC3`, `16UC1`, `32FC1`, `bayer_bggr8`, `bayer_gbrg8`, `bayer_grbg8`, `bayer_rggb8`, `bgr8`, `bgra8`, `mono8`, `mono16`, `rgb8`, `rgba8`, `yuv422`
 string encoding
 
 # Byte length of a single row

--- a/schemas/ros1/RawImage.msg
+++ b/schemas/ros1/RawImage.msg
@@ -16,6 +16,8 @@ uint32 width
 uint32 height
 
 # Encoding of the raw image data
+# 
+# Values supported by Foxglove Studio: `8UC1`, `8UC3`, `16UC1`, `32FC1`, `bayer_bggr8`, `bayer_gbrg8`, `bayer_grbg8`, `bayer_rggb8`, `bgr8`, `bgra8`, `mono8`, `mono16`, `rgb8`, `rgba8`, `yuv422`
 string encoding
 
 # Byte length of a single row

--- a/schemas/ros2/CameraCalibration.msg
+++ b/schemas/ros2/CameraCalibration.msg
@@ -17,7 +17,7 @@ uint32 height
 
 # Name of distortion model
 # 
-# Values supported by Foxglove Studio: `plumb_bob` and `rational_polynomial`
+# Supported values: `plumb_bob` and `rational_polynomial`
 string distortion_model
 
 # Distortion parameters

--- a/schemas/ros2/CameraCalibration.msg
+++ b/schemas/ros2/CameraCalibration.msg
@@ -16,6 +16,8 @@ uint32 width
 uint32 height
 
 # Name of distortion model
+# 
+# Values supported by Foxglove Studio: `plumb_bob` and `rational_polynomial`
 string distortion_model
 
 # Distortion parameters

--- a/schemas/ros2/CompressedImage.msg
+++ b/schemas/ros2/CompressedImage.msg
@@ -13,4 +13,6 @@ string frame_id
 uint8[] data
 
 # Image format
+# 
+# Values supported by Foxglove Studio: `webp`, `jpeg`, `png`
 string format

--- a/schemas/ros2/CompressedImage.msg
+++ b/schemas/ros2/CompressedImage.msg
@@ -14,5 +14,5 @@ uint8[] data
 
 # Image format
 # 
-# Values supported by Foxglove Studio: `webp`, `jpeg`, `png`
+# Supported values: `webp`, `jpeg`, `png`
 string format

--- a/schemas/ros2/RawImage.msg
+++ b/schemas/ros2/RawImage.msg
@@ -17,7 +17,7 @@ uint32 height
 
 # Encoding of the raw image data
 # 
-# Values supported by Foxglove Studio: `8UC1`, `8UC3`, `16UC1`, `32FC1`, `bayer_bggr8`, `bayer_gbrg8`, `bayer_grbg8`, `bayer_rggb8`, `bgr8`, `bgra8`, `mono8`, `mono16`, `rgb8`, `rgba8`, `yuv422`
+# Supported values: `8UC1`, `8UC3`, `16UC1`, `32FC1`, `bayer_bggr8`, `bayer_gbrg8`, `bayer_grbg8`, `bayer_rggb8`, `bgr8`, `bgra8`, `mono8`, `mono16`, `rgb8`, `rgba8`, `yuv422`
 string encoding
 
 # Byte length of a single row

--- a/schemas/ros2/RawImage.msg
+++ b/schemas/ros2/RawImage.msg
@@ -16,6 +16,8 @@ uint32 width
 uint32 height
 
 # Encoding of the raw image data
+# 
+# Values supported by Foxglove Studio: `8UC1`, `8UC3`, `16UC1`, `32FC1`, `bayer_bggr8`, `bayer_gbrg8`, `bayer_grbg8`, `bayer_rggb8`, `bgr8`, `bgra8`, `mono8`, `mono16`, `rgb8`, `rgba8`, `yuv422`
 string encoding
 
 # Byte length of a single row

--- a/schemas/typescript/CameraCalibration.ts
+++ b/schemas/typescript/CameraCalibration.ts
@@ -19,7 +19,7 @@ export type CameraCalibration = {
   /**
    * Name of distortion model
    * 
-   * Values supported by Foxglove Studio: `plumb_bob` and `rational_polynomial`
+   * Supported values: `plumb_bob` and `rational_polynomial`
    */
   distortion_model: string;
 

--- a/schemas/typescript/CameraCalibration.ts
+++ b/schemas/typescript/CameraCalibration.ts
@@ -16,7 +16,11 @@ export type CameraCalibration = {
   /** Image height */
   height: number;
 
-  /** Name of distortion model */
+  /**
+   * Name of distortion model
+   * 
+   * Values supported by Foxglove Studio: `plumb_bob` and `rational_polynomial`
+   */
   distortion_model: string;
 
   /** Distortion parameters */

--- a/schemas/typescript/CompressedImage.ts
+++ b/schemas/typescript/CompressedImage.ts
@@ -16,7 +16,7 @@ export type CompressedImage = {
   /**
    * Image format
    * 
-   * Values supported by Foxglove Studio: `webp`, `jpeg`, `png`
+   * Supported values: `webp`, `jpeg`, `png`
    */
   format: string;
 };

--- a/schemas/typescript/CompressedImage.ts
+++ b/schemas/typescript/CompressedImage.ts
@@ -13,6 +13,10 @@ export type CompressedImage = {
   /** Compressed image data */
   data: Uint8Array;
 
-  /** Image format */
+  /**
+   * Image format
+   * 
+   * Values supported by Foxglove Studio: `webp`, `jpeg`, `png`
+   */
   format: string;
 };

--- a/schemas/typescript/RawImage.ts
+++ b/schemas/typescript/RawImage.ts
@@ -19,7 +19,7 @@ export type RawImage = {
   /**
    * Encoding of the raw image data
    * 
-   * Values supported by Foxglove Studio: `8UC1`, `8UC3`, `16UC1`, `32FC1`, `bayer_bggr8`, `bayer_gbrg8`, `bayer_grbg8`, `bayer_rggb8`, `bgr8`, `bgra8`, `mono8`, `mono16`, `rgb8`, `rgba8`, `yuv422`
+   * Supported values: `8UC1`, `8UC3`, `16UC1`, `32FC1`, `bayer_bggr8`, `bayer_gbrg8`, `bayer_grbg8`, `bayer_rggb8`, `bgr8`, `bgra8`, `mono8`, `mono16`, `rgb8`, `rgba8`, `yuv422`
    */
   encoding: string;
 

--- a/schemas/typescript/RawImage.ts
+++ b/schemas/typescript/RawImage.ts
@@ -16,7 +16,11 @@ export type RawImage = {
   /** Image height */
   height: number;
 
-  /** Encoding of the raw image data */
+  /**
+   * Encoding of the raw image data
+   * 
+   * Values supported by Foxglove Studio: `8UC1`, `8UC3`, `16UC1`, `32FC1`, `bayer_bggr8`, `bayer_gbrg8`, `bayer_grbg8`, `bayer_rggb8`, `bgr8`, `bgra8`, `mono8`, `mono16`, `rgb8`, `rgba8`, `yuv422`
+   */
   encoding: string;
 
   /** Byte length of a single row */


### PR DESCRIPTION
**Public-Facing Changes**
Added information about Foxglove Studio's supported values for CameraCalibration.distortion_model, RawImage.encoding, and CompressedImage.format.

**Description**
Closes https://github.com/foxglove/schemas/issues/32