### PR TITLE
[Python] Add foxglove-schemas-flatbuffer package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Install Flatbuffer compiler
+        run: |
+          curl -LO https://github.com/google/flatbuffers/releases/download/v22.10.26/Linux.flatc.binary.clang++-12.zip 
+          echo "0821af82a3a736b0ba9235c02219df24d1f042dd  Linux.flatc.binary.clang++-12.zip" | shasum -a 1 -c
+          unzip Linux.flatc.binary.clang++-12.zip
+          sudo mv flatc /usr/local/bin
       - uses: arduino/setup-protoc@v1
       - uses: actions/setup-node@v2
         with:
@@ -38,10 +44,7 @@ jobs:
 
       - name: Validate Flatbuffer definitions
         run: |
-          curl -LO https://github.com/google/flatbuffers/releases/download/v22.10.26/Linux.flatc.binary.clang++-12.zip 
-          echo "0821af82a3a736b0ba9235c02219df24d1f042dd  Linux.flatc.binary.clang++-12.zip" | shasum -a 1 -c
-          unzip Linux.flatc.binary.clang++-12.zip
-          output=$(./flatc --ts -o /dev/null ./schemas/flatbuffer/*.fbs)
+          output=$(flatc --ts -o /dev/null ./schemas/flatbuffer/*.fbs)
           if [ -n "$output" ]; then
             echo "::error::Flatbuffer schema compilation had warnings or errors. Fix them to proceed:"
             echo "$output"
@@ -65,6 +68,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: arduino/setup-protoc@v1
+      - name: Install Flatbuffer compiler
+        run: |
+          curl -LO https://github.com/google/flatbuffers/releases/download/v22.10.26/Linux.flatc.binary.clang++-12.zip 
+          echo "0821af82a3a736b0ba9235c02219df24d1f042dd  Linux.flatc.binary.clang++-12.zip" | shasum -a 1 -c
+          unzip Linux.flatc.binary.clang++-12.zip
+          sudo mv flatc /usr/local/bin
       - uses: actions/setup-python@v4
         with:
           python-version: 3.7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,10 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install Flatbuffer compiler
         run: |
-          curl -LO https://github.com/google/flatbuffers/releases/download/v22.10.26/Linux.flatc.binary.clang++-12.zip 
-          echo "0821af82a3a736b0ba9235c02219df24d1f042dd  Linux.flatc.binary.clang++-12.zip" | shasum -a 1 -c
+          curl -LO https://github.com/google/flatbuffers/releases/download/v23.1.21/Linux.flatc.binary.clang++-12.zip
+          echo "359dbbf56153cc1b022170a228adfde4199f67dc  Linux.flatc.binary.clang++-12.zip" | shasum -a 1 -c
           unzip Linux.flatc.binary.clang++-12.zip
+          rm Linux.flatc.binary.clang++-12.zip
           sudo mv flatc /usr/local/bin
       - uses: arduino/setup-protoc@v1
       - uses: actions/setup-node@v2
@@ -70,9 +71,10 @@ jobs:
       - uses: arduino/setup-protoc@v1
       - name: Install Flatbuffer compiler
         run: |
-          curl -LO https://github.com/google/flatbuffers/releases/download/v22.10.26/Linux.flatc.binary.clang++-12.zip 
-          echo "0821af82a3a736b0ba9235c02219df24d1f042dd  Linux.flatc.binary.clang++-12.zip" | shasum -a 1 -c
+          curl -LO https://github.com/google/flatbuffers/releases/download/v23.1.21/Linux.flatc.binary.clang++-12.zip
+          echo "359dbbf56153cc1b022170a228adfde4199f67dc  Linux.flatc.binary.clang++-12.zip" | shasum -a 1 -c
           unzip Linux.flatc.binary.clang++-12.zip
+          rm Linux.flatc.binary.clang++-12.zip
           sudo mv flatc /usr/local/bin
       - uses: actions/setup-python@v4
         with:

--- a/python/.gitignore
+++ b/python/.gitignore
@@ -4,3 +4,4 @@ dist
 *.egg-info
 *_pb2*
 .pytest_cache
+foxglove-schemas-flatbuffer/foxglove_schemas_flatbuffer/*.py

--- a/python/.gitignore
+++ b/python/.gitignore
@@ -5,3 +5,4 @@ dist
 *_pb2*
 .pytest_cache
 foxglove-schemas-flatbuffer/foxglove_schemas_flatbuffer/*.py
+foxglove-schemas-flatbuffer/foxglove_schemas_flatbuffer/*.bfbs

--- a/python/Makefile
+++ b/python/Makefile
@@ -10,11 +10,17 @@ endif
 
 .PHONY: generate-flatbuffer
 generate-flatbuffer:
-	rm -rf foxglove-schemas-flatbuffer/foxglove_schemas_flatbuffer/*.py
+	find foxglove-schemas-flatbuffer/foxglove_schemas_flatbuffer ! -name '__init__.py' -type f -exec rm -f {} +
 	pipenv run flatc \
 		--python \
 		-o foxglove-schemas-flatbuffer/foxglove_schemas_flatbuffer \
 		../schemas/flatbuffer/*.fbs
+	pipenv run flatc \
+		-b \
+		--schema \
+		-o foxglove-schemas-flatbuffer/foxglove_schemas_flatbuffer \
+		../schemas/flatbuffer/*.fbs
+	rm foxglove-schemas-flatbuffer/foxglove_schemas_flatbuffer/foxglove/__init__.py
 	mv foxglove-schemas-flatbuffer/foxglove_schemas_flatbuffer/foxglove/* foxglove-schemas-flatbuffer/foxglove_schemas_flatbuffer
 	rmdir foxglove-schemas-flatbuffer/foxglove_schemas_flatbuffer/foxglove
 	sed -E $(SED_ARGS) 's/from foxglove\./from \./g' foxglove-schemas-flatbuffer/foxglove_schemas_flatbuffer/*.py

--- a/python/Makefile
+++ b/python/Makefile
@@ -8,6 +8,17 @@ else
 SED_ARGS = -i
 endif
 
+.PHONY: generate-flatbuffer
+generate-flatbuffer:
+	rm -rf foxglove-schemas-flatbuffer/foxglove_schemas_flatbuffer/*.py
+	pipenv run flatc \
+		--python \
+		-o foxglove-schemas-flatbuffer/foxglove_schemas_flatbuffer \
+		../schemas/flatbuffer/*.fbs
+	mv foxglove-schemas-flatbuffer/foxglove_schemas_flatbuffer/foxglove/* foxglove-schemas-flatbuffer/foxglove_schemas_flatbuffer
+	rmdir foxglove-schemas-flatbuffer/foxglove_schemas_flatbuffer/foxglove
+	sed -E $(SED_ARGS) 's/from foxglove\./from \./g' foxglove-schemas-flatbuffer/foxglove_schemas_flatbuffer/*.py
+
 .PHONY: generate-protobuf
 generate-protobuf:
 	rm -rf foxglove-schemas-protobuf/foxglove_schemas_protobuf/*_pb2*
@@ -23,11 +34,13 @@ generate-protobuf:
 	sed -E $(SED_ARGS) 's/foxglove\./foxglove_/g' foxglove-schemas-protobuf/foxglove_schemas_protobuf/*_pb2.pyi
 
 .PHONY: build
-build: pipenv generate-protobuf
+build: pipenv generate-flatbuffer generate-protobuf
+	pipenv run python -m build foxglove-schemas-flatbuffer
 	pipenv run python -m build foxglove-schemas-protobuf
 
 .PHONY: test
-test: pipenv generate-protobuf
+test: pipenv generate-flatbuffer generate-protobuf
+	pipenv run python -m pytest foxglove-schemas-flatbuffer
 	pipenv run python -m pytest foxglove-schemas-protobuf
 
 .PHONY: clean

--- a/python/Pipfile
+++ b/python/Pipfile
@@ -4,7 +4,9 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
+flatbuffers = "*"
 protobuf = "*"
+foxglove-schemas-flatbuffers = {editable = true, path = "./foxglove-schemas-flatbuffer"}
 foxglove-schemas-protobuf = {editable = true, path = "./foxglove-schemas-protobuf"}
 
 [dev-packages]

--- a/python/Pipfile.lock
+++ b/python/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "2ef152665d5b58c6132d4c3c506f7f020a9b5e6bc5af82f2a334b23d8b8ed8a4"
+            "sha256": "0977308fe2b87d61ab61ec8c80a37a085c04790c1d151f3492fb6c61f1acef60"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,90 +16,71 @@
         ]
     },
     "default": {
+        "flatbuffers": {
+            "hashes": [
+                "sha256:2e4101b291b14f21e87ea20b7bf7127b11563f6084e352d2d708bddd545c9265",
+                "sha256:a948913bbb5d83c43a1193d7943c90e6c0ab732e7f2983111104250aeb61ff85"
+            ],
+            "index": "pypi",
+            "version": "==23.1.21"
+        },
+        "foxglove-schemas-flatbuffer": {
+            "editable": true,
+            "path": "./foxglove-schemas-flatbuffer"
+        },
+        "foxglove-schemas-flatbuffers": {
+            "editable": true,
+            "path": "./foxglove-schemas-flatbuffer"
+        },
         "foxglove-schemas-protobuf": {
             "editable": true,
             "path": "./foxglove-schemas-protobuf"
         },
         "protobuf": {
             "hashes": [
-                "sha256:2c9c2ed7466ad565f18668aa4731c535511c5d9a40c6da39524bccf43e441719",
-                "sha256:48e2cd6b88c6ed3d5877a3ea40df79d08374088e89bedc32557348848dff250b",
-                "sha256:5b0834e61fb38f34ba8840d7dcb2e5a2f03de0c714e0293b3963b79db26de8ce",
-                "sha256:61f21493d96d2a77f9ca84fefa105872550ab5ef71d21c458eb80edcf4885a99",
-                "sha256:6e0be9f09bf9b6cf497b27425487706fa48c6d1632ddd94dab1a5fe11a422392",
-                "sha256:6e312e280fbe3c74ea9e080d9e6080b636798b5e3939242298b591064470b06b",
-                "sha256:7eb8f2cc41a34e9c956c256e3ac766cf4e1a4c9c925dc757a41a01be3e852965",
-                "sha256:84ea107016244dfc1eecae7684f7ce13c788b9a644cd3fca5b77871366556444",
-                "sha256:9227c14010acd9ae7702d6467b4625b6fe853175a6b150e539b21d2b2f2b409c",
-                "sha256:a419cc95fca8694804709b8c4f2326266d29659b126a93befe210f5bbc772536",
-                "sha256:a7d0ea43949d45b836234f4ebb5ba0b22e7432d065394b532cdca8f98415e3cf",
-                "sha256:b5ab0b8918c136345ff045d4b3d5f719b505b7c8af45092d7f45e304f55e50a1",
-                "sha256:e575c57dc8b5b2b2caa436c16d44ef6981f2235eb7179bfc847557886376d740",
-                "sha256:f9eae277dd240ae19bb06ff4e2346e771252b0e619421965504bd1b1bba7c5fa"
+                "sha256:1f22ac0ca65bb70a876060d96d914dae09ac98d114294f77584b0d2644fa9c30",
+                "sha256:237216c3326d46808a9f7c26fd1bd4b20015fb6867dc5d263a493ef9a539293b",
+                "sha256:27f4d15021da6d2b706ddc3860fac0a5ddaba34ab679dc182b60a8bb4e1121cc",
+                "sha256:299ea899484ee6f44604deb71f424234f654606b983cb496ea2a53e3c63ab791",
+                "sha256:3d164928ff0727d97022957c2b849250ca0e64777ee31efd7d6de2e07c494717",
+                "sha256:6ab80df09e3208f742c98443b6166bcb70d65f52cfeb67357d52032ea1ae9bec",
+                "sha256:78a28c9fa223998472886c77042e9b9afb6fe4242bd2a2a5aced88e3f4422aa7",
+                "sha256:7cd532c4566d0e6feafecc1059d04c7915aec8e182d1cf7adee8b24ef1e2e6ab",
+                "sha256:89f9149e4a0169cddfc44c74f230d7743002e3aa0b9472d8c28f0388102fc4c2",
+                "sha256:a53fd3f03e578553623272dc46ac2f189de23862e68565e83dde203d41b76fc5",
+                "sha256:b135410244ebe777db80298297a97fbb4c862c881b4403b71bac9d4107d61fd1",
+                "sha256:b98d0148f84e3a3c569e19f52103ca1feacdac0d2df8d6533cf983d1fda28462",
+                "sha256:d1736130bce8cf131ac7957fa26880ca19227d4ad68b4888b3be0dea1f95df97",
+                "sha256:f45460f9ee70a0ec1b6694c6e4e348ad2019275680bd68a1d9314b8c7e01e574"
             ],
             "index": "pypi",
-            "version": "==4.21.9"
+            "version": "==4.21.12"
         }
     },
     "develop": {
         "attrs": {
             "hashes": [
-                "sha256:29adc2665447e5191d0e7c568fde78b21f9672d344281d0c6e1ab085429b22b6",
-                "sha256:86efa402f67bf2df34f51a335487cf46b1ec130d02b8d39fd248abfd30da551c"
+                "sha256:29e95c7f6778868dbd49170f98f8818f78f3dc5e0e37c0b1f474e3561b240836",
+                "sha256:c9227bfc2f01993c03f68db37d1d15c9690188323c067c641f1a35ca58185f99"
             ],
-            "markers": "python_version >= '3.5'",
-            "version": "==22.1.0"
-        },
-        "black": {
-            "hashes": [
-                "sha256:14ff67aec0a47c424bc99b71005202045dc09270da44a27848d534600ac64fc7",
-                "sha256:197df8509263b0b8614e1df1756b1dd41be6738eed2ba9e9769f3880c2b9d7b6",
-                "sha256:1e464456d24e23d11fced2bc8c47ef66d471f845c7b7a42f3bd77bf3d1789650",
-                "sha256:2039230db3c6c639bd84efe3292ec7b06e9214a2992cd9beb293d639c6402edb",
-                "sha256:21199526696b8f09c3997e2b4db8d0b108d801a348414264d2eb8eb2532e540d",
-                "sha256:2644b5d63633702bc2c5f3754b1b475378fbbfb481f62319388235d0cd104c2d",
-                "sha256:432247333090c8c5366e69627ccb363bc58514ae3e63f7fc75c54b1ea80fa7de",
-                "sha256:444ebfb4e441254e87bad00c661fe32df9969b2bf224373a448d8aca2132b395",
-                "sha256:5b9b29da4f564ba8787c119f37d174f2b69cdfdf9015b7d8c5c16121ddc054ae",
-                "sha256:5cc42ca67989e9c3cf859e84c2bf014f6633db63d1cbdf8fdb666dcd9e77e3fa",
-                "sha256:5d8f74030e67087b219b032aa33a919fae8806d49c867846bfacde57f43972ef",
-                "sha256:72ef3925f30e12a184889aac03d77d031056860ccae8a1e519f6cbb742736383",
-                "sha256:819dc789f4498ecc91438a7de64427c73b45035e2e3680c92e18795a839ebb66",
-                "sha256:915ace4ff03fdfff953962fa672d44be269deb2eaf88499a0f8805221bc68c87",
-                "sha256:9311e99228ae10023300ecac05be5a296f60d2fd10fff31cf5c1fa4ca4b1988d",
-                "sha256:974308c58d057a651d182208a484ce80a26dac0caef2895836a92dd6ebd725e0",
-                "sha256:b8b49776299fece66bffaafe357d929ca9451450f5466e997a7285ab0fe28e3b",
-                "sha256:c957b2b4ea88587b46cf49d1dc17681c1e672864fd7af32fc1e9664d572b3458",
-                "sha256:e41a86c6c650bcecc6633ee3180d80a025db041a8e2398dcc059b3afa8382cd4",
-                "sha256:f513588da599943e0cde4e32cc9879e825d58720d6557062d1098c5ad80080e1",
-                "sha256:fba8a281e570adafb79f7755ac8721b6cf1bbf691186a287e990c7929c7692ff"
-            ],
-            "index": "pypi",
-            "version": "==22.10.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==22.2.0"
         },
         "build": {
             "hashes": [
-                "sha256:1a07724e891cbd898923145eb7752ee7653674c511378eb9c7691aab1612bc3c",
-                "sha256:38a7a2b7a0bdc61a42a0a67509d88c71ecfc37b393baba770fae34e20929ff69"
+                "sha256:af266720050a66c893a6096a2f410989eeac74ff9a68ba194b3f6473e8e26171",
+                "sha256:d5b71264afdb5951d6704482aac78de887c80691c52b88a9ad195983ca2c9269"
             ],
             "index": "pypi",
-            "version": "==0.9.0"
+            "version": "==0.10.0"
         },
         "certifi": {
             "hashes": [
-                "sha256:0d9c601124e5a6ba9712dbc60d9c53c21e34f5f641fe83002317394311bdce14",
-                "sha256:90c1a32f1d68f940488354e36370f6cca89f0f106db09518524c88d6ed83f382"
+                "sha256:35824b4c3a97115964b408844d64aa14db1cc518f6562e8d7261699d1350a9e3",
+                "sha256:4ad3232f5e926d6718ec31cfc1fcadfde020920e278684144551c91769c7bc18"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==2022.9.24"
-        },
-        "click": {
-            "hashes": [
-                "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e",
-                "sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48"
-            ],
-            "markers": "python_version >= '3.7'",
-            "version": "==8.1.3"
+            "version": "==2022.12.7"
         },
         "distlib": {
             "hashes": [
@@ -110,49 +91,27 @@
         },
         "exceptiongroup": {
             "hashes": [
-                "sha256:542adf9dea4055530d6e1279602fa5cb11dab2395fa650b8674eaec35fc4a828",
-                "sha256:bd14967b79cd9bdb54d97323216f8fdf533e278df937aa2a90089e7d6e06e5ec"
+                "sha256:327cbda3da756e2de031a3107b81ab7b3770a602c4d16ca618298c526f4bec1e",
+                "sha256:bcb67d800a4497e1b404c2dd44fca47d3b7a5e5433dbab67f96c1a685cdfdf23"
             ],
             "markers": "python_version < '3.11'",
-            "version": "==1.0.4"
+            "version": "==1.1.0"
         },
         "filelock": {
             "hashes": [
-                "sha256:55447caa666f2198c5b6b13a26d2084d26fa5b115c00d065664b2124680c4edc",
-                "sha256:617eb4e5eedc82fc5f47b6d61e4d11cb837c56cb4544e39081099fa17ad109d4"
+                "sha256:7b319f24340b51f55a2bf7a12ac0755a9b03e718311dac567a0f4f7fabd2f5de",
+                "sha256:f58d535af89bb9ad5cd4df046f741f8553a418c01a7856bf0d173bbc9f6bd16d"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==3.8.0"
-        },
-        "flake8": {
-            "hashes": [
-                "sha256:6fbe320aad8d6b95cec8b8e47bc933004678dc63095be98528b7bdd2a9f510db",
-                "sha256:7a1cf6b73744f5806ab95e526f6f0d8c01c66d7bbe349562d22dfca20610b248"
-            ],
-            "index": "pypi",
-            "version": "==5.0.4"
+            "version": "==3.9.0"
         },
         "iniconfig": {
             "hashes": [
-                "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3",
-                "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"
+                "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3",
+                "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"
             ],
-            "version": "==1.1.1"
-        },
-        "mccabe": {
-            "hashes": [
-                "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325",
-                "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e"
-            ],
-            "markers": "python_version >= '3.6'",
-            "version": "==0.7.0"
-        },
-        "mypy-extensions": {
-            "hashes": [
-                "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d",
-                "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"
-            ],
-            "version": "==0.4.3"
+            "markers": "python_version >= '3.7'",
+            "version": "==2.0.0"
         },
         "mypy-protobuf": {
             "hashes": [
@@ -162,53 +121,29 @@
             "index": "pypi",
             "version": "==3.4.0"
         },
-        "nodeenv": {
-            "hashes": [
-                "sha256:27083a7b96a25f2f5e1d8cb4b6317ee8aeda3bdd121394e5ac54e498028a042e",
-                "sha256:e0e7f7dfb85fc5394c6fe1e8fa98131a2473e04311a45afb6508f7cf1836fa2b"
-            ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6'",
-            "version": "==1.7.0"
-        },
         "packaging": {
             "hashes": [
-                "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb",
-                "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"
-            ],
-            "markers": "python_version >= '3.6'",
-            "version": "==21.3"
-        },
-        "pathspec": {
-            "hashes": [
-                "sha256:88c2606f2c1e818b978540f73ecc908e13999c6c3a383daf3705652ae79807a5",
-                "sha256:8f6bf73e5758fd365ef5d58ce09ac7c27d2833a8d7da51712eac6e27e35141b0"
+                "sha256:714ac14496c3e68c99c29b00845f7a2b85f3bb6f1078fd9f72fd20f0570002b2",
+                "sha256:b6ad297f8907de0fa2fe1ccbd26fdaf387f5f47c7275fedf8cce89f99446cf97"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==0.10.2"
-        },
-        "pep517": {
-            "hashes": [
-                "sha256:4ba4446d80aed5b5eac6509ade100bff3e7943a8489de249654a5ae9b33ee35b",
-                "sha256:ae69927c5c172be1add9203726d4b84cf3ebad1edcd5f71fcdc746e66e829f59"
-            ],
-            "markers": "python_version >= '3.6'",
-            "version": "==0.13.0"
+            "version": "==23.0"
         },
         "pipenv": {
             "hashes": [
-                "sha256:7a75fe8df36226a84ad482d37c003eab131378339bc421b553d8425253980b2c",
-                "sha256:e69f64477e83595f3b891e1e58b1b1355d4c593432e63b078dc1be9bd93c5066"
+                "sha256:18a3eba519e36d59f0d5a7f9c42bd268521e4b9b7b3d1bd6adcf131569323275",
+                "sha256:dd62abe8efa34b3d13e47b226bd151a1110dc5591557c559beca7d52efb55c18"
             ],
             "index": "pypi",
-            "version": "==2022.11.11"
+            "version": "==2023.2.4"
         },
         "platformdirs": {
             "hashes": [
-                "sha256:1006647646d80f16130f052404c6b901e80ee4ed6bef6792e1f238a8969106f7",
-                "sha256:af0276409f9a02373d540bf8480021a048711d572745aef4b7842dad245eba10"
+                "sha256:8a1228abb1ef82d788f74139988b137e78692984ec7b08eaa6c65f1723af28f9",
+                "sha256:b1d5eb14f221506f50d6604a561f4c5786d9e80355219694a1b244bcd96f4567"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.5.4"
+            "version": "==3.0.0"
         },
         "pluggy": {
             "hashes": [
@@ -220,71 +155,47 @@
         },
         "protobuf": {
             "hashes": [
-                "sha256:2c9c2ed7466ad565f18668aa4731c535511c5d9a40c6da39524bccf43e441719",
-                "sha256:48e2cd6b88c6ed3d5877a3ea40df79d08374088e89bedc32557348848dff250b",
-                "sha256:5b0834e61fb38f34ba8840d7dcb2e5a2f03de0c714e0293b3963b79db26de8ce",
-                "sha256:61f21493d96d2a77f9ca84fefa105872550ab5ef71d21c458eb80edcf4885a99",
-                "sha256:6e0be9f09bf9b6cf497b27425487706fa48c6d1632ddd94dab1a5fe11a422392",
-                "sha256:6e312e280fbe3c74ea9e080d9e6080b636798b5e3939242298b591064470b06b",
-                "sha256:7eb8f2cc41a34e9c956c256e3ac766cf4e1a4c9c925dc757a41a01be3e852965",
-                "sha256:84ea107016244dfc1eecae7684f7ce13c788b9a644cd3fca5b77871366556444",
-                "sha256:9227c14010acd9ae7702d6467b4625b6fe853175a6b150e539b21d2b2f2b409c",
-                "sha256:a419cc95fca8694804709b8c4f2326266d29659b126a93befe210f5bbc772536",
-                "sha256:a7d0ea43949d45b836234f4ebb5ba0b22e7432d065394b532cdca8f98415e3cf",
-                "sha256:b5ab0b8918c136345ff045d4b3d5f719b505b7c8af45092d7f45e304f55e50a1",
-                "sha256:e575c57dc8b5b2b2caa436c16d44ef6981f2235eb7179bfc847557886376d740",
-                "sha256:f9eae277dd240ae19bb06ff4e2346e771252b0e619421965504bd1b1bba7c5fa"
+                "sha256:1f22ac0ca65bb70a876060d96d914dae09ac98d114294f77584b0d2644fa9c30",
+                "sha256:237216c3326d46808a9f7c26fd1bd4b20015fb6867dc5d263a493ef9a539293b",
+                "sha256:27f4d15021da6d2b706ddc3860fac0a5ddaba34ab679dc182b60a8bb4e1121cc",
+                "sha256:299ea899484ee6f44604deb71f424234f654606b983cb496ea2a53e3c63ab791",
+                "sha256:3d164928ff0727d97022957c2b849250ca0e64777ee31efd7d6de2e07c494717",
+                "sha256:6ab80df09e3208f742c98443b6166bcb70d65f52cfeb67357d52032ea1ae9bec",
+                "sha256:78a28c9fa223998472886c77042e9b9afb6fe4242bd2a2a5aced88e3f4422aa7",
+                "sha256:7cd532c4566d0e6feafecc1059d04c7915aec8e182d1cf7adee8b24ef1e2e6ab",
+                "sha256:89f9149e4a0169cddfc44c74f230d7743002e3aa0b9472d8c28f0388102fc4c2",
+                "sha256:a53fd3f03e578553623272dc46ac2f189de23862e68565e83dde203d41b76fc5",
+                "sha256:b135410244ebe777db80298297a97fbb4c862c881b4403b71bac9d4107d61fd1",
+                "sha256:b98d0148f84e3a3c569e19f52103ca1feacdac0d2df8d6533cf983d1fda28462",
+                "sha256:d1736130bce8cf131ac7957fa26880ca19227d4ad68b4888b3be0dea1f95df97",
+                "sha256:f45460f9ee70a0ec1b6694c6e4e348ad2019275680bd68a1d9314b8c7e01e574"
             ],
             "index": "pypi",
-            "version": "==4.21.9"
+            "version": "==4.21.12"
         },
-        "pycodestyle": {
+        "pyproject-hooks": {
             "hashes": [
-                "sha256:2c9607871d58c76354b697b42f5d57e1ada7d261c261efac224b664affdc5785",
-                "sha256:d1735fc58b418fd7c5f658d28d943854f8a849b01a5d0a1e6f3f3fdd0166804b"
+                "sha256:283c11acd6b928d2f6a7c73fa0d01cb2bdc5f07c57a2eeb6e83d5e56b97976f8",
+                "sha256:f271b298b97f5955d53fb12b72c1fb1948c22c1a6b70b315c54cedaca0264ef5"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==2.9.1"
-        },
-        "pyflakes": {
-            "hashes": [
-                "sha256:4579f67d887f804e67edb544428f264b7b24f435b263c4614f384135cea553d2",
-                "sha256:491feb020dca48ccc562a8c0cbe8df07ee13078df59813b83959cbdada312ea3"
-            ],
-            "markers": "python_version >= '3.6'",
-            "version": "==2.5.0"
-        },
-        "pyparsing": {
-            "hashes": [
-                "sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb",
-                "sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc"
-            ],
-            "markers": "python_full_version >= '3.6.8'",
-            "version": "==3.0.9"
-        },
-        "pyright": {
-            "hashes": [
-                "sha256:25917a14d873252c5c2e6fdbec322888c0480f6db95068ff6459befa9af3c92a",
-                "sha256:4bcb167251419b3b736137b0535cb6bbfb5bef16eb74057eaf3ccaccb01d74c1"
-            ],
-            "index": "pypi",
-            "version": "==1.1.280"
+            "markers": "python_version >= '3.7'",
+            "version": "==1.0.0"
         },
         "pytest": {
             "hashes": [
-                "sha256:892f933d339f068883b6fd5a459f03d85bfcb355e4981e146d2c7616c21fef71",
-                "sha256:c4014eb40e10f11f355ad4e3c2fb2c6c6d1919c73f3b5a433de4708202cade59"
+                "sha256:c7c6ca206e93355074ae32f7403e8ea12163b1163c976fee7d4d84027c162be5",
+                "sha256:d45e0952f3727241918b8fd0f376f5ff6b301cc0777c6f9a556935c92d8a7d42"
             ],
             "index": "pypi",
-            "version": "==7.2.0"
+            "version": "==7.2.1"
         },
         "setuptools": {
             "hashes": [
-                "sha256:d0b9a8433464d5800cbe05094acf5c6d52a91bfac9b52bcfc4d41382be5d5d31",
-                "sha256:e197a19aa8ec9722928f2206f8de752def0e4c9fc6953527360d1c36d94ddb2f"
+                "sha256:95f00380ef2ffa41d9bba85d95b27689d923c93dfbafed4aecd7cf988a25e012",
+                "sha256:bb6d8e508de562768f2027902929f8523932fcd1fb784e6d573d2cafac995a48"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==65.5.1"
+            "version": "==67.3.2"
         },
         "tomli": {
             "hashes": [
@@ -296,26 +207,18 @@
         },
         "types-protobuf": {
             "hashes": [
-                "sha256:97af5ce70d890fdb94cb0c906f5a6624ca2fef58bc04e27990a25509e992a950",
-                "sha256:e9b45008d106e1d10cc77a29d2d344b85c0f01e2e643aaccf32f69e9e81b0cdd"
+                "sha256:39167012ead0bc5920b6322a1e4dc2d088f66a34b84cce39bb88500e49ac955a",
+                "sha256:8c105b906569e9d53ba033465880d9ef17a59bf3ba8ab656d24c9eadb9d8a056"
             ],
-            "version": "==3.20.4.5"
-        },
-        "typing-extensions": {
-            "hashes": [
-                "sha256:1511434bb92bf8dd198c12b1cc812e800d4181cfcb867674e0f8279cc93087aa",
-                "sha256:16fa4864408f655d35ec496218b85f79b3437c829e93320c7c9215ccfd92489e"
-            ],
-            "index": "pypi",
-            "version": "==4.4.0"
+            "version": "==4.21.0.6"
         },
         "virtualenv": {
             "hashes": [
-                "sha256:8691e3ff9387f743e00f6bb20f70121f5e4f596cae754531f2b3b3a1b1ac696e",
-                "sha256:efd66b00386fdb7dbe4822d172303f40cd05e50e01740b19ea42425cbe653e29"
+                "sha256:37a640ba82ed40b226599c522d411e4be5edb339a0c0de030c0dc7b646d61590",
+                "sha256:54eb59e7352b573aa04d53f80fc9736ed0ad5143af445a1e539aada6eb947dd1"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==20.16.7"
+            "markers": "python_version >= '3.7'",
+            "version": "==20.19.0"
         },
         "virtualenv-clone": {
             "hashes": [

--- a/python/foxglove-schemas-flatbuffer/README.md
+++ b/python/foxglove-schemas-flatbuffer/README.md
@@ -1,0 +1,23 @@
+# Foxglove Schemas (Flatbuffer)
+
+This package provides [Flatbuffer](https://google.github.io/flatbuffers/) classes for [Foxglove Schemas](https://foxglove.dev/docs/studio/messages/introduction).
+
+## Installation
+
+Install via [Pipenv](https://pipenv.pypa.io/en/latest/) by adding `foxglove-schemas-flatbuffer` to your `Pipfile` or via the command line:
+
+```bash
+pipenv install foxglove-schemas-flatbuffer
+```
+
+## Usage
+
+Import types from the `foxglove` module as follows:
+
+```py
+from foxglove_schemas_flatbuffer.CompressedImage import CompressedImage
+```
+
+## Stay in touch
+
+Join our [Slack channel](https://foxglove.dev/join-slack) to ask questions, share feedback, and stay up to date on what our team is working on.

--- a/python/foxglove-schemas-flatbuffer/README.md
+++ b/python/foxglove-schemas-flatbuffer/README.md
@@ -15,7 +15,22 @@ pipenv install foxglove-schemas-flatbuffer
 Import types from the `foxglove` module as follows:
 
 ```py
-from foxglove_schemas_flatbuffer.CompressedImage import CompressedImage
+import flatbuffers
+import foxglove_schemas_flatbuffer.CompressedImage as CompressedImage
+from foxglove_schemas_flatbuffer import get_schema
+
+builder = flatbuffers.Builder(1024)
+png = builder.CreateString("png")
+CompressedImage.Start(builder)
+CompressedImage.AddFormat(builder, png)
+img = CompressedImage.End(builder)
+builder.Finish(img)
+
+# Serialized flatbuffer schema
+schema_data = get_schema("CompressedImage")
+
+# Serialized CompressedImage message
+msg_data = builder.Output()
 ```
 
 ## Stay in touch

--- a/python/foxglove-schemas-flatbuffer/foxglove_schemas_flatbuffer/__init__.py
+++ b/python/foxglove-schemas-flatbuffer/foxglove_schemas_flatbuffer/__init__.py
@@ -1,0 +1,5 @@
+import importlib.resources as pkg_resources
+
+
+def get_schema(name: str) -> bytes:
+    return pkg_resources.read_binary(__package__, name + ".bfbs")

--- a/python/foxglove-schemas-flatbuffer/foxglove_schemas_flatbuffer/__init__.py
+++ b/python/foxglove-schemas-flatbuffer/foxglove_schemas_flatbuffer/__init__.py
@@ -1,5 +1,5 @@
-import importlib.resources as pkg_resources
+import importlib.resources as resources
 
 
 def get_schema(name: str) -> bytes:
-    return pkg_resources.read_binary(__package__, name + ".bfbs")
+    return resources.read_binary(__package__, name + ".bfbs")

--- a/python/foxglove-schemas-flatbuffer/pyproject.toml
+++ b/python/foxglove-schemas-flatbuffer/pyproject.toml
@@ -1,0 +1,11 @@
+[build-system]
+requires = [
+    "setuptools>=42",
+    "wheel"
+]
+build-backend = "setuptools.build_meta"
+
+[tool.pytest.ini_options]
+addopts = "-vv --color=yes"
+log_cli = true
+xfail_strict = true

--- a/python/foxglove-schemas-flatbuffer/setup.cfg
+++ b/python/foxglove-schemas-flatbuffer/setup.cfg
@@ -18,4 +18,4 @@ packages = find:
 python_requires = >=3.7
 
 [options.package_data]
-foxglove_schemas_flatbuffer = *.bin
+foxglove_schemas_flatbuffer = *.bfbs

--- a/python/foxglove-schemas-flatbuffer/setup.cfg
+++ b/python/foxglove-schemas-flatbuffer/setup.cfg
@@ -1,0 +1,21 @@
+[metadata]
+name = foxglove-schemas-flatbuffer
+version = 0.0.1
+description = Flatbuffer classes for Foxglove Schemas
+long_description = file: README.md
+long_description_content_type = text/markdown
+url = https://github.com/foxglove/schemas
+classifiers =
+    Programming Language :: Python :: 3
+    License :: OSI Approved :: MIT License
+    Operating System :: OS Independent
+
+[options]
+install_requires = 
+    flatbuffers
+install_package_data = True
+packages = find:
+python_requires = >=3.7
+
+[options.package_data]
+foxglove_schemas_flatbuffer = *.bin

--- a/python/foxglove-schemas-flatbuffer/tests/test_schemas.py
+++ b/python/foxglove-schemas-flatbuffer/tests/test_schemas.py
@@ -9,3 +9,13 @@ def test_schemas():
     img = RawImage.End(builder)
     builder.Finish(img)
     buf = builder.Output()
+    assert buf is not None
+    assert len(buf) > 0
+
+
+def test_get_schema():
+    from foxglove_schemas_flatbuffer import get_schema
+
+    schema = get_schema("RawImage")
+    assert schema is not None
+    assert len(schema) > 0

--- a/python/foxglove-schemas-flatbuffer/tests/test_schemas.py
+++ b/python/foxglove-schemas-flatbuffer/tests/test_schemas.py
@@ -1,0 +1,11 @@
+def test_schemas():
+    import flatbuffers
+    import foxglove_schemas_flatbuffer.RawImage as RawImage
+
+    builder = flatbuffers.Builder(1024)
+    png = builder.CreateString("png")
+    RawImage.Start(builder)
+    RawImage.AddEncoding(builder, png)
+    img = RawImage.End(builder)
+    builder.Finish(img)
+    buf = builder.Output()


### PR DESCRIPTION
**Public-Facing Changes**
- [Python] New foxglove-schemas-flatbuffer package exporting Python classes for Flatbuffer types and a get_schema() method for retrieving binary .bfbs schemas

**Description**
This closely resembles the foxglove-schemas-protobuf package
