### PR TITLE
Add `zfp` as a supported CompressedImage format

### DIFF
--- a/internal/schemas.ts
+++ b/internal/schemas.ts
@@ -785,7 +785,8 @@ const CompressedImage: FoxgloveMessageSchema = {
     {
       name: "format",
       type: { type: "primitive", name: "string" },
-      description: "Image format\n\nSupported values: `webp`, `jpeg`, `png`, `zfp`\n\nFor ZFP compression, only 2D fields are supported and the data must be prefixed with a full ZFP header (`ZFP_HEADER_FULL`).",
+      description:
+        "Image format\n\nSupported values: `webp`, `jpeg`, `png`, `zfp`\n\nFor ZFP compression, only 2D fields are supported and the data must be prefixed with a full ZFP header (`ZFP_HEADER_FULL`).",
     },
   ],
 };

--- a/internal/schemas.ts
+++ b/internal/schemas.ts
@@ -785,7 +785,7 @@ const CompressedImage: FoxgloveMessageSchema = {
     {
       name: "format",
       type: { type: "primitive", name: "string" },
-      description: "Image format\n\nSupported values: `webp`, `jpeg`, `png`",
+      description: "Image format\n\nSupported values: `webp`, `jpeg`, `png`, `zfp`\n\nFor ZFP compression, only 2D fields are supported and the data must be prefixed with a full ZFP header (`ZFP_HEADER_FULL`).",
     },
   ],
 };

--- a/ros_foxglove_msgs/ros1/CompressedImage.msg
+++ b/ros_foxglove_msgs/ros1/CompressedImage.msg
@@ -14,5 +14,7 @@ uint8[] data
 
 # Image format
 # 
-# Supported values: `webp`, `jpeg`, `png`
+# Supported values: `webp`, `jpeg`, `png`, `zfp`
+# 
+# For ZFP compression, only 2D fields are supported and the data must be prefixed with a full ZFP header (`ZFP_HEADER_FULL`).
 string format

--- a/ros_foxglove_msgs/ros2/CompressedImage.msg
+++ b/ros_foxglove_msgs/ros2/CompressedImage.msg
@@ -14,5 +14,7 @@ uint8[] data
 
 # Image format
 # 
-# Supported values: `webp`, `jpeg`, `png`
+# Supported values: `webp`, `jpeg`, `png`, `zfp`
+# 
+# For ZFP compression, only 2D fields are supported and the data must be prefixed with a full ZFP header (`ZFP_HEADER_FULL`).
 string format

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -606,7 +606,9 @@ string
 
 Image format
 
-Supported values: `webp`, `jpeg`, `png`
+Supported values: `webp`, `jpeg`, `png`, `zfp`
+
+For ZFP compression, only 2D fields are supported and the data must be prefixed with a full ZFP header (`ZFP_HEADER_FULL`).
 
 </td>
 </tr>

--- a/schemas/flatbuffer/CompressedImage.fbs
+++ b/schemas/flatbuffer/CompressedImage.fbs
@@ -17,7 +17,9 @@ table CompressedImage {
 
   /// Image format
   /// 
-  /// Supported values: `webp`, `jpeg`, `png`
+  /// Supported values: `webp`, `jpeg`, `png`, `zfp`
+  /// 
+  /// For ZFP compression, only 2D fields are supported and the data must be prefixed with a full ZFP header (`ZFP_HEADER_FULL`).
   format:string;
 }
 

--- a/schemas/jsonschema/CompressedImage.json
+++ b/schemas/jsonschema/CompressedImage.json
@@ -31,7 +31,7 @@
     },
     "format": {
       "type": "string",
-      "description": "Image format\n\nSupported values: `webp`, `jpeg`, `png`"
+      "description": "Image format\n\nSupported values: `webp`, `jpeg`, `png`, `zfp`\n\nFor ZFP compression, only 2D fields are supported and the data must be prefixed with a full ZFP header (`ZFP_HEADER_FULL`)."
     }
   }
 }

--- a/schemas/jsonschema/index.ts
+++ b/schemas/jsonschema/index.ts
@@ -326,7 +326,7 @@ export const CompressedImage = {
     },
     "format": {
       "type": "string",
-      "description": "Image format\n\nSupported values: `webp`, `jpeg`, `png`"
+      "description": "Image format\n\nSupported values: `webp`, `jpeg`, `png`, `zfp`\n\nFor ZFP compression, only 2D fields are supported and the data must be prefixed with a full ZFP header (`ZFP_HEADER_FULL`)."
     }
   }
 };

--- a/schemas/proto/foxglove/CompressedImage.proto
+++ b/schemas/proto/foxglove/CompressedImage.proto
@@ -19,6 +19,8 @@ message CompressedImage {
 
   // Image format
   // 
-  // Supported values: `webp`, `jpeg`, `png`
+  // Supported values: `webp`, `jpeg`, `png`, `zfp`
+  // 
+  // For ZFP compression, only 2D fields are supported and the data must be prefixed with a full ZFP header (`ZFP_HEADER_FULL`).
   string format = 3;
 }

--- a/schemas/ros1/CompressedImage.msg
+++ b/schemas/ros1/CompressedImage.msg
@@ -14,5 +14,7 @@ uint8[] data
 
 # Image format
 # 
-# Supported values: `webp`, `jpeg`, `png`
+# Supported values: `webp`, `jpeg`, `png`, `zfp`
+# 
+# For ZFP compression, only 2D fields are supported and the data must be prefixed with a full ZFP header (`ZFP_HEADER_FULL`).
 string format

--- a/schemas/ros2/CompressedImage.msg
+++ b/schemas/ros2/CompressedImage.msg
@@ -14,5 +14,7 @@ uint8[] data
 
 # Image format
 # 
-# Supported values: `webp`, `jpeg`, `png`
+# Supported values: `webp`, `jpeg`, `png`, `zfp`
+# 
+# For ZFP compression, only 2D fields are supported and the data must be prefixed with a full ZFP header (`ZFP_HEADER_FULL`).
 string format

--- a/schemas/typescript/CompressedImage.ts
+++ b/schemas/typescript/CompressedImage.ts
@@ -16,7 +16,9 @@ export type CompressedImage = {
   /**
    * Image format
    * 
-   * Supported values: `webp`, `jpeg`, `png`
+   * Supported values: `webp`, `jpeg`, `png`, `zfp`
+   * 
+   * For ZFP compression, only 2D fields are supported and the data must be prefixed with a full ZFP header (`ZFP_HEADER_FULL`).
    */
   format: string;
 };


### PR DESCRIPTION
**Public-Facing Changes**
- `zfp` is documented as a valid format for CompressedImage messages. The schema docs describe the constraints (header required, data must be 2D)
