### PR TITLE
Add units to PointsAnnotation and CircleAnnotation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         run: |
           changes=$(git status --porcelain)
           if [ -n "$changes" ]; then
-            echo "::error::The following generated files need to be updated. Run `yarn update-generated-files` to update them."
+            echo "::error::The following generated files need to be updated. Run 'yarn update-generated-files' to update them."
             echo "$changes"
             exit 1
           else

--- a/internal/schemas.ts
+++ b/internal/schemas.ts
@@ -1040,17 +1040,17 @@ const CircleAnnotation: FoxgloveMessageSchema = {
     {
       name: "position",
       type: { type: "nested", schema: Point2 },
-      description: "Center of the circle in 2D image coordinates",
+      description: "Center of the circle in 2D image coordinates ([0,w] x [0,h] pixels)",
     },
     {
       name: "diameter",
       type: { type: "primitive", name: "float64" },
-      description: "Circle diameter",
+      description: "Circle diameter in pixels",
     },
     {
       name: "thickness",
       type: { type: "primitive", name: "float64" },
-      description: "Line thickness",
+      description: "Line thickness in pixels",
     },
     {
       name: "fill_color",
@@ -1102,7 +1102,7 @@ const PointsAnnotation: FoxgloveMessageSchema = {
     {
       name: "points",
       type: { type: "nested", schema: Point2 },
-      description: "Points in 2D image coordinates",
+      description: "Points in 2D image coordinates ([0,w] x [0,h] pixels)",
       array: true,
     },
     {
@@ -1125,7 +1125,7 @@ const PointsAnnotation: FoxgloveMessageSchema = {
     {
       name: "thickness",
       type: { type: "primitive", name: "float64" },
-      description: "Stroke thickness",
+      description: "Stroke thickness in pixels",
     },
   ],
 };

--- a/internal/schemas.ts
+++ b/internal/schemas.ts
@@ -1040,7 +1040,7 @@ const CircleAnnotation: FoxgloveMessageSchema = {
     {
       name: "position",
       type: { type: "nested", schema: Point2 },
-      description: "Center of the circle in 2D image coordinates ([0,w] x [0,h] pixels)",
+      description: "Center of the circle in 2D image coordinates (pixels)",
     },
     {
       name: "diameter",
@@ -1102,7 +1102,7 @@ const PointsAnnotation: FoxgloveMessageSchema = {
     {
       name: "points",
       type: { type: "nested", schema: Point2 },
-      description: "Points in 2D image coordinates ([0,w] x [0,h] pixels)",
+      description: "Points in 2D image coordinates (pixels)",
       array: true,
     },
     {

--- a/ros_foxglove_msgs/ros1/CircleAnnotation.msg
+++ b/ros_foxglove_msgs/ros1/CircleAnnotation.msg
@@ -6,13 +6,13 @@
 # Timestamp of circle
 time timestamp
 
-# Center of the circle in 2D image coordinates
+# Center of the circle in 2D image coordinates (pixels)
 foxglove_msgs/Point2 position
 
-# Circle diameter
+# Circle diameter in pixels
 float64 diameter
 
-# Line thickness
+# Line thickness in pixels
 float64 thickness
 
 # Fill color

--- a/ros_foxglove_msgs/ros1/PointsAnnotation.msg
+++ b/ros_foxglove_msgs/ros1/PointsAnnotation.msg
@@ -23,7 +23,7 @@ uint8 LINE_LIST=4
 # Type of points annotation to draw
 uint8 type
 
-# Points in 2D image coordinates
+# Points in 2D image coordinates (pixels)
 foxglove_msgs/Point2[] points
 
 # Outline color
@@ -35,5 +35,5 @@ foxglove_msgs/Color[] outline_colors
 # Fill color
 foxglove_msgs/Color fill_color
 
-# Stroke thickness
+# Stroke thickness in pixels
 float64 thickness

--- a/ros_foxglove_msgs/ros2/CircleAnnotation.msg
+++ b/ros_foxglove_msgs/ros2/CircleAnnotation.msg
@@ -6,13 +6,13 @@
 # Timestamp of circle
 builtin_interfaces/Time timestamp
 
-# Center of the circle in 2D image coordinates
+# Center of the circle in 2D image coordinates (pixels)
 foxglove_msgs/Point2 position
 
-# Circle diameter
+# Circle diameter in pixels
 float64 diameter
 
-# Line thickness
+# Line thickness in pixels
 float64 thickness
 
 # Fill color

--- a/ros_foxglove_msgs/ros2/PointsAnnotation.msg
+++ b/ros_foxglove_msgs/ros2/PointsAnnotation.msg
@@ -23,7 +23,7 @@ uint8 LINE_LIST=4
 # Type of points annotation to draw
 uint8 type
 
-# Points in 2D image coordinates
+# Points in 2D image coordinates (pixels)
 foxglove_msgs/Point2[] points
 
 # Outline color
@@ -35,5 +35,5 @@ foxglove_msgs/Color[] outline_colors
 # Fill color
 foxglove_msgs/Color fill_color
 
-# Stroke thickness
+# Stroke thickness in pixels
 float64 thickness

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -424,7 +424,7 @@ Timestamp of circle
 </td>
 <td>
 
-Center of the circle in 2D image coordinates
+Center of the circle in 2D image coordinates (pixels)
 
 </td>
 </tr>
@@ -437,7 +437,7 @@ float64
 </td>
 <td>
 
-Circle diameter
+Circle diameter in pixels
 
 </td>
 </tr>
@@ -450,7 +450,7 @@ float64
 </td>
 <td>
 
-Line thickness
+Line thickness in pixels
 
 </td>
 </tr>
@@ -1813,7 +1813,7 @@ Type of points annotation to draw
 </td>
 <td>
 
-Points in 2D image coordinates
+Points in 2D image coordinates (pixels)
 
 </td>
 </tr>
@@ -1865,7 +1865,7 @@ float64
 </td>
 <td>
 
-Stroke thickness
+Stroke thickness in pixels
 
 </td>
 </tr>

--- a/schemas/flatbuffer/CircleAnnotation.fbs
+++ b/schemas/flatbuffer/CircleAnnotation.fbs
@@ -11,13 +11,13 @@ table CircleAnnotation {
   /// Timestamp of circle
   timestamp:Time;
 
-  /// Center of the circle in 2D image coordinates
+  /// Center of the circle in 2D image coordinates (pixels)
   position:foxglove.Point2;
 
-  /// Circle diameter
+  /// Circle diameter in pixels
   diameter:double;
 
-  /// Line thickness
+  /// Line thickness in pixels
   thickness:double;
 
   /// Fill color

--- a/schemas/flatbuffer/PointsAnnotation.fbs
+++ b/schemas/flatbuffer/PointsAnnotation.fbs
@@ -30,7 +30,7 @@ table PointsAnnotation {
   /// Type of points annotation to draw
   type:PointsAnnotationType;
 
-  /// Points in 2D image coordinates
+  /// Points in 2D image coordinates (pixels)
   points:[foxglove.Point2];
 
   /// Outline color
@@ -42,7 +42,7 @@ table PointsAnnotation {
   /// Fill color
   fill_color:foxglove.Color;
 
-  /// Stroke thickness
+  /// Stroke thickness in pixels
   thickness:double;
 }
 

--- a/schemas/jsonschema/CircleAnnotation.json
+++ b/schemas/jsonschema/CircleAnnotation.json
@@ -22,7 +22,7 @@
     },
     "position": {
       "title": "foxglove.Point2",
-      "description": "Center of the circle in 2D image coordinates",
+      "description": "Center of the circle in 2D image coordinates (pixels)",
       "type": "object",
       "properties": {
         "x": {
@@ -37,11 +37,11 @@
     },
     "diameter": {
       "type": "number",
-      "description": "Circle diameter"
+      "description": "Circle diameter in pixels"
     },
     "thickness": {
       "type": "number",
-      "description": "Line thickness"
+      "description": "Line thickness in pixels"
     },
     "fill_color": {
       "title": "foxglove.Color",

--- a/schemas/jsonschema/ImageAnnotations.json
+++ b/schemas/jsonschema/ImageAnnotations.json
@@ -29,7 +29,7 @@
           },
           "position": {
             "title": "foxglove.Point2",
-            "description": "Center of the circle in 2D image coordinates",
+            "description": "Center of the circle in 2D image coordinates (pixels)",
             "type": "object",
             "properties": {
               "x": {
@@ -44,11 +44,11 @@
           },
           "diameter": {
             "type": "number",
-            "description": "Circle diameter"
+            "description": "Circle diameter in pixels"
           },
           "thickness": {
             "type": "number",
-            "description": "Line thickness"
+            "description": "Line thickness in pixels"
           },
           "fill_color": {
             "title": "foxglove.Color",
@@ -170,7 +170,7 @@
                 }
               }
             },
-            "description": "Points in 2D image coordinates"
+            "description": "Points in 2D image coordinates (pixels)"
           },
           "outline_color": {
             "title": "foxglove.Color",
@@ -247,7 +247,7 @@
           },
           "thickness": {
             "type": "number",
-            "description": "Stroke thickness"
+            "description": "Stroke thickness in pixels"
           }
         }
       },

--- a/schemas/jsonschema/PointsAnnotation.json
+++ b/schemas/jsonschema/PointsAnnotation.json
@@ -67,7 +67,7 @@
           }
         }
       },
-      "description": "Points in 2D image coordinates"
+      "description": "Points in 2D image coordinates (pixels)"
     },
     "outline_color": {
       "title": "foxglove.Color",
@@ -144,7 +144,7 @@
     },
     "thickness": {
       "type": "number",
-      "description": "Stroke thickness"
+      "description": "Stroke thickness in pixels"
     }
   }
 }

--- a/schemas/jsonschema/index.ts
+++ b/schemas/jsonschema/index.ts
@@ -198,7 +198,7 @@ export const CircleAnnotation = {
     },
     "position": {
       "title": "foxglove.Point2",
-      "description": "Center of the circle in 2D image coordinates",
+      "description": "Center of the circle in 2D image coordinates (pixels)",
       "type": "object",
       "properties": {
         "x": {
@@ -213,11 +213,11 @@ export const CircleAnnotation = {
     },
     "diameter": {
       "type": "number",
-      "description": "Circle diameter"
+      "description": "Circle diameter in pixels"
     },
     "thickness": {
       "type": "number",
-      "description": "Line thickness"
+      "description": "Line thickness in pixels"
     },
     "fill_color": {
       "title": "foxglove.Color",
@@ -833,7 +833,7 @@ export const ImageAnnotations = {
           },
           "position": {
             "title": "foxglove.Point2",
-            "description": "Center of the circle in 2D image coordinates",
+            "description": "Center of the circle in 2D image coordinates (pixels)",
             "type": "object",
             "properties": {
               "x": {
@@ -848,11 +848,11 @@ export const ImageAnnotations = {
           },
           "diameter": {
             "type": "number",
-            "description": "Circle diameter"
+            "description": "Circle diameter in pixels"
           },
           "thickness": {
             "type": "number",
-            "description": "Line thickness"
+            "description": "Line thickness in pixels"
           },
           "fill_color": {
             "title": "foxglove.Color",
@@ -974,7 +974,7 @@ export const ImageAnnotations = {
                 }
               }
             },
-            "description": "Points in 2D image coordinates"
+            "description": "Points in 2D image coordinates (pixels)"
           },
           "outline_color": {
             "title": "foxglove.Color",
@@ -1051,7 +1051,7 @@ export const ImageAnnotations = {
           },
           "thickness": {
             "type": "number",
-            "description": "Stroke thickness"
+            "description": "Stroke thickness in pixels"
           }
         }
       },
@@ -4032,7 +4032,7 @@ export const PointsAnnotation = {
           }
         }
       },
-      "description": "Points in 2D image coordinates"
+      "description": "Points in 2D image coordinates (pixels)"
     },
     "outline_color": {
       "title": "foxglove.Color",
@@ -4109,7 +4109,7 @@ export const PointsAnnotation = {
     },
     "thickness": {
       "type": "number",
-      "description": "Stroke thickness"
+      "description": "Stroke thickness in pixels"
     }
   }
 };

--- a/schemas/proto/foxglove/CircleAnnotation.proto
+++ b/schemas/proto/foxglove/CircleAnnotation.proto
@@ -13,13 +13,13 @@ message CircleAnnotation {
   // Timestamp of circle
   google.protobuf.Timestamp timestamp = 1;
 
-  // Center of the circle in 2D image coordinates
+  // Center of the circle in 2D image coordinates (pixels)
   foxglove.Point2 position = 2;
 
-  // Circle diameter
+  // Circle diameter in pixels
   double diameter = 3;
 
-  // Line thickness
+  // Line thickness in pixels
   double thickness = 4;
 
   // Fill color

--- a/schemas/proto/foxglove/PointsAnnotation.proto
+++ b/schemas/proto/foxglove/PointsAnnotation.proto
@@ -32,7 +32,7 @@ message PointsAnnotation {
   // Type of points annotation to draw
   Type type = 2;
 
-  // Points in 2D image coordinates
+  // Points in 2D image coordinates (pixels)
   repeated foxglove.Point2 points = 3;
 
   // Outline color
@@ -44,6 +44,6 @@ message PointsAnnotation {
   // Fill color
   foxglove.Color fill_color = 6;
 
-  // Stroke thickness
+  // Stroke thickness in pixels
   double thickness = 7;
 }

--- a/schemas/ros1/CircleAnnotation.msg
+++ b/schemas/ros1/CircleAnnotation.msg
@@ -6,13 +6,13 @@
 # Timestamp of circle
 time timestamp
 
-# Center of the circle in 2D image coordinates
+# Center of the circle in 2D image coordinates (pixels)
 foxglove_msgs/Point2 position
 
-# Circle diameter
+# Circle diameter in pixels
 float64 diameter
 
-# Line thickness
+# Line thickness in pixels
 float64 thickness
 
 # Fill color

--- a/schemas/ros1/PointsAnnotation.msg
+++ b/schemas/ros1/PointsAnnotation.msg
@@ -23,7 +23,7 @@ uint8 LINE_LIST=4
 # Type of points annotation to draw
 uint8 type
 
-# Points in 2D image coordinates
+# Points in 2D image coordinates (pixels)
 foxglove_msgs/Point2[] points
 
 # Outline color
@@ -35,5 +35,5 @@ foxglove_msgs/Color[] outline_colors
 # Fill color
 foxglove_msgs/Color fill_color
 
-# Stroke thickness
+# Stroke thickness in pixels
 float64 thickness

--- a/schemas/ros2/CircleAnnotation.msg
+++ b/schemas/ros2/CircleAnnotation.msg
@@ -6,13 +6,13 @@
 # Timestamp of circle
 builtin_interfaces/Time timestamp
 
-# Center of the circle in 2D image coordinates
+# Center of the circle in 2D image coordinates (pixels)
 foxglove_msgs/Point2 position
 
-# Circle diameter
+# Circle diameter in pixels
 float64 diameter
 
-# Line thickness
+# Line thickness in pixels
 float64 thickness
 
 # Fill color

--- a/schemas/ros2/PointsAnnotation.msg
+++ b/schemas/ros2/PointsAnnotation.msg
@@ -23,7 +23,7 @@ uint8 LINE_LIST=4
 # Type of points annotation to draw
 uint8 type
 
-# Points in 2D image coordinates
+# Points in 2D image coordinates (pixels)
 foxglove_msgs/Point2[] points
 
 # Outline color
@@ -35,5 +35,5 @@ foxglove_msgs/Color[] outline_colors
 # Fill color
 foxglove_msgs/Color fill_color
 
-# Stroke thickness
+# Stroke thickness in pixels
 float64 thickness

--- a/schemas/typescript/CircleAnnotation.ts
+++ b/schemas/typescript/CircleAnnotation.ts
@@ -9,13 +9,13 @@ export type CircleAnnotation = {
   /** Timestamp of circle */
   timestamp: Time;
 
-  /** Center of the circle in 2D image coordinates */
+  /** Center of the circle in 2D image coordinates (pixels) */
   position: Point2;
 
-  /** Circle diameter */
+  /** Circle diameter in pixels */
   diameter: number;
 
-  /** Line thickness */
+  /** Line thickness in pixels */
   thickness: number;
 
   /** Fill color */

--- a/schemas/typescript/PointsAnnotation.ts
+++ b/schemas/typescript/PointsAnnotation.ts
@@ -13,7 +13,7 @@ export type PointsAnnotation = {
   /** Type of points annotation to draw */
   type: PointsAnnotationType;
 
-  /** Points in 2D image coordinates */
+  /** Points in 2D image coordinates (pixels) */
   points: Point2[];
 
   /** Outline color */
@@ -25,6 +25,6 @@ export type PointsAnnotation = {
   /** Fill color */
   fill_color: Color;
 
-  /** Stroke thickness */
+  /** Stroke thickness in pixels */
   thickness: number;
 };


### PR DESCRIPTION
I'm a little meh on this change since we already say `2D image space` and a `Point2d` has `x, y` fields.

@jtbandes I think I need to run some script to re-generate the schemas?