### PR TITLE
Remove "all float64s" comment from PointCloud schema

### DIFF
--- a/internal/schemas.ts
+++ b/internal/schemas.ts
@@ -1285,7 +1285,7 @@ const PointCloud: FoxgloveMessageSchema = {
       type: { type: "nested", schema: PackedElementField },
       array: true,
       description:
-        "Fields in `data`. At least 2 coordinate fields from `x`, `y`, and `z` (all `float64`s) are required for each point's position; `red`, `green`, `blue`, and `alpha` (all `float64`s) are optional for customizing each point's color.",
+        "Fields in `data`. At least 2 coordinate fields from `x`, `y`, and `z` are required for each point's position; `red`, `green`, `blue`, and `alpha` are optional for customizing each point's color.",
     },
     {
       name: "data",

--- a/ros_foxglove_msgs/ros1/PointCloud.msg
+++ b/ros_foxglove_msgs/ros1/PointCloud.msg
@@ -15,7 +15,7 @@ geometry_msgs/Pose pose
 # Number of bytes between points in the `data`
 uint32 point_stride
 
-# Fields in `data`. At least 2 coordinate fields from `x`, `y`, and `z` (all `float64`s) are required for each point's position; `red`, `green`, `blue`, and `alpha` (all `float64`s) are optional for customizing each point's color.
+# Fields in `data`. At least 2 coordinate fields from `x`, `y`, and `z` are required for each point's position; `red`, `green`, `blue`, and `alpha` are optional for customizing each point's color.
 foxglove_msgs/PackedElementField[] fields
 
 # Point data, interpreted using `fields`

--- a/ros_foxglove_msgs/ros2/PointCloud.msg
+++ b/ros_foxglove_msgs/ros2/PointCloud.msg
@@ -15,7 +15,7 @@ geometry_msgs/Pose pose
 # Number of bytes between points in the `data`
 uint32 point_stride
 
-# Fields in `data`. At least 2 coordinate fields from `x`, `y`, and `z` (all `float64`s) are required for each point's position; `red`, `green`, `blue`, and `alpha` (all `float64`s) are optional for customizing each point's color.
+# Fields in `data`. At least 2 coordinate fields from `x`, `y`, and `z` are required for each point's position; `red`, `green`, `blue`, and `alpha` are optional for customizing each point's color.
 foxglove_msgs/PackedElementField[] fields
 
 # Point data, interpreted using `fields`

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -1749,7 +1749,7 @@ Number of bytes between points in the `data`
 </td>
 <td>
 
-Fields in `data`. At least 2 coordinate fields from `x`, `y`, and `z` (all `float64`s) are required for each point's position; `red`, `green`, `blue`, and `alpha` (all `float64`s) are optional for customizing each point's color.
+Fields in `data`. At least 2 coordinate fields from `x`, `y`, and `z` are required for each point's position; `red`, `green`, `blue`, and `alpha` are optional for customizing each point's color.
 
 </td>
 </tr>

--- a/schemas/flatbuffer/PointCloud.fbs
+++ b/schemas/flatbuffer/PointCloud.fbs
@@ -20,7 +20,7 @@ table PointCloud {
   /// Number of bytes between points in the `data`
   point_stride:uint32;
 
-  /// Fields in `data`. At least 2 coordinate fields from `x`, `y`, and `z` (all `float64`s) are required for each point's position; `red`, `green`, `blue`, and `alpha` (all `float64`s) are optional for customizing each point's color.
+  /// Fields in `data`. At least 2 coordinate fields from `x`, `y`, and `z` are required for each point's position; `red`, `green`, `blue`, and `alpha` are optional for customizing each point's color.
   fields:[foxglove.PackedElementField];
 
   /// Point data, interpreted using `fields`

--- a/schemas/jsonschema/PointCloud.json
+++ b/schemas/jsonschema/PointCloud.json
@@ -138,7 +138,7 @@
           }
         }
       },
-      "description": "Fields in `data`. At least 2 coordinate fields from `x`, `y`, and `z` (all `float64`s) are required for each point's position; `red`, `green`, `blue`, and `alpha` (all `float64`s) are optional for customizing each point's color."
+      "description": "Fields in `data`. At least 2 coordinate fields from `x`, `y`, and `z` are required for each point's position; `red`, `green`, `blue`, and `alpha` are optional for customizing each point's color."
     },
     "data": {
       "type": "string",

--- a/schemas/jsonschema/index.ts
+++ b/schemas/jsonschema/index.ts
@@ -3953,7 +3953,7 @@ export const PointCloud = {
           }
         }
       },
-      "description": "Fields in `data`. At least 2 coordinate fields from `x`, `y`, and `z` (all `float64`s) are required for each point's position; `red`, `green`, `blue`, and `alpha` (all `float64`s) are optional for customizing each point's color."
+      "description": "Fields in `data`. At least 2 coordinate fields from `x`, `y`, and `z` are required for each point's position; `red`, `green`, `blue`, and `alpha` are optional for customizing each point's color."
     },
     "data": {
       "type": "string",

--- a/schemas/proto/foxglove/PointCloud.proto
+++ b/schemas/proto/foxglove/PointCloud.proto
@@ -22,7 +22,7 @@ message PointCloud {
   // Number of bytes between points in the `data`
   fixed32 point_stride = 4;
 
-  // Fields in `data`. At least 2 coordinate fields from `x`, `y`, and `z` (all `float64`s) are required for each point's position; `red`, `green`, `blue`, and `alpha` (all `float64`s) are optional for customizing each point's color.
+  // Fields in `data`. At least 2 coordinate fields from `x`, `y`, and `z` are required for each point's position; `red`, `green`, `blue`, and `alpha` are optional for customizing each point's color.
   repeated foxglove.PackedElementField fields = 5;
 
   // Point data, interpreted using `fields`

--- a/schemas/ros1/PointCloud.msg
+++ b/schemas/ros1/PointCloud.msg
@@ -15,7 +15,7 @@ geometry_msgs/Pose pose
 # Number of bytes between points in the `data`
 uint32 point_stride
 
-# Fields in `data`. At least 2 coordinate fields from `x`, `y`, and `z` (all `float64`s) are required for each point's position; `red`, `green`, `blue`, and `alpha` (all `float64`s) are optional for customizing each point's color.
+# Fields in `data`. At least 2 coordinate fields from `x`, `y`, and `z` are required for each point's position; `red`, `green`, `blue`, and `alpha` are optional for customizing each point's color.
 foxglove_msgs/PackedElementField[] fields
 
 # Point data, interpreted using `fields`

--- a/schemas/ros2/PointCloud.msg
+++ b/schemas/ros2/PointCloud.msg
@@ -15,7 +15,7 @@ geometry_msgs/Pose pose
 # Number of bytes between points in the `data`
 uint32 point_stride
 
-# Fields in `data`. At least 2 coordinate fields from `x`, `y`, and `z` (all `float64`s) are required for each point's position; `red`, `green`, `blue`, and `alpha` (all `float64`s) are optional for customizing each point's color.
+# Fields in `data`. At least 2 coordinate fields from `x`, `y`, and `z` are required for each point's position; `red`, `green`, `blue`, and `alpha` are optional for customizing each point's color.
 foxglove_msgs/PackedElementField[] fields
 
 # Point data, interpreted using `fields`

--- a/schemas/typescript/PointCloud.ts
+++ b/schemas/typescript/PointCloud.ts
@@ -18,7 +18,7 @@ export type PointCloud = {
   /** Number of bytes between points in the `data` */
   point_stride: number;
 
-  /** Fields in `data`. At least 2 coordinate fields from `x`, `y`, and `z` (all `float64`s) are required for each point's position; `red`, `green`, `blue`, and `alpha` (all `float64`s) are optional for customizing each point's color. */
+  /** Fields in `data`. At least 2 coordinate fields from `x`, `y`, and `z` are required for each point's position; `red`, `green`, `blue`, and `alpha` are optional for customizing each point's color. */
   fields: PackedElementField[];
 
   /** Point data, interpreted using `fields` */


### PR DESCRIPTION
These fields do not need to be float 64s, they can also be float 32. This confused a customer who thought they had to send float64.

@jtbandes do we support the other field types or only float32/64? If we don't support the other field types we should remove them.