### PR TITLE
Extending PointsAnnotation and CircleAnnotation with object_id

### DIFF
--- a/internal/schemas.ts
+++ b/internal/schemas.ts
@@ -1076,6 +1076,11 @@ const CircleAnnotation: FoxgloveMessageSchema = {
       type: { type: "nested", schema: Color },
       description: "Outline color",
     },
+    {
+      name: "object_id",
+      type: { type: "primitive", name: "string" },
+      description: "Id of circle",
+    },
   ],
 };
 
@@ -1140,6 +1145,11 @@ const PointsAnnotation: FoxgloveMessageSchema = {
       name: "thickness",
       type: { type: "primitive", name: "float64" },
       description: "Stroke thickness in pixels",
+    },
+    {
+      name: "object_id",
+      type: { type: "primitive", name: "string" },
+      description: "Id of group points",
     },
   ],
 };

--- a/ros_foxglove_msgs/ros1/CircleAnnotation.msg
+++ b/ros_foxglove_msgs/ros1/CircleAnnotation.msg
@@ -20,3 +20,6 @@ foxglove_msgs/Color fill_color
 
 # Outline color
 foxglove_msgs/Color outline_color
+
+# Id of circle
+string object_id

--- a/ros_foxglove_msgs/ros1/PointsAnnotation.msg
+++ b/ros_foxglove_msgs/ros1/PointsAnnotation.msg
@@ -37,3 +37,6 @@ foxglove_msgs/Color fill_color
 
 # Stroke thickness in pixels
 float64 thickness
+
+# Id of group points
+string object_id

--- a/ros_foxglove_msgs/ros2/CircleAnnotation.msg
+++ b/ros_foxglove_msgs/ros2/CircleAnnotation.msg
@@ -20,3 +20,6 @@ foxglove_msgs/Color fill_color
 
 # Outline color
 foxglove_msgs/Color outline_color
+
+# Id of circle
+string object_id

--- a/ros_foxglove_msgs/ros2/PointsAnnotation.msg
+++ b/ros_foxglove_msgs/ros2/PointsAnnotation.msg
@@ -37,3 +37,6 @@ foxglove_msgs/Color fill_color
 
 # Stroke thickness in pixels
 float64 thickness
+
+# Id of group points
+string object_id

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -482,6 +482,19 @@ Outline color
 
 </td>
 </tr>
+<tr>
+<td><code>object_id</code></td>
+<td>
+
+string
+
+</td>
+<td>
+
+Id of circle
+
+</td>
+</tr>
 </table>
 
 ## Color
@@ -1906,6 +1919,19 @@ float64
 <td>
 
 Stroke thickness in pixels
+
+</td>
+</tr>
+<tr>
+<td><code>object_id</code></td>
+<td>
+
+string
+
+</td>
+<td>
+
+Id of group points
 
 </td>
 </tr>

--- a/schemas/flatbuffer/CircleAnnotation.fbs
+++ b/schemas/flatbuffer/CircleAnnotation.fbs
@@ -25,6 +25,9 @@ table CircleAnnotation {
 
   /// Outline color
   outline_color:foxglove.Color;
+
+  /// Id of circle
+  object_id:string;
 }
 
 root_type CircleAnnotation;

--- a/schemas/flatbuffer/PointsAnnotation.fbs
+++ b/schemas/flatbuffer/PointsAnnotation.fbs
@@ -44,6 +44,9 @@ table PointsAnnotation {
 
   /// Stroke thickness in pixels
   thickness:double;
+
+  /// Id of group points
+  object_id:string;
 }
 
 root_type PointsAnnotation;

--- a/schemas/jsonschema/CircleAnnotation.json
+++ b/schemas/jsonschema/CircleAnnotation.json
@@ -88,6 +88,10 @@
           "description": "Alpha value between 0 and 1"
         }
       }
+    },
+    "object_id": {
+      "type": "string",
+      "description": "Id of circle"
     }
   }
 }

--- a/schemas/jsonschema/ImageAnnotations.json
+++ b/schemas/jsonschema/ImageAnnotations.json
@@ -95,6 +95,10 @@
                 "description": "Alpha value between 0 and 1"
               }
             }
+          },
+          "object_id": {
+            "type": "string",
+            "description": "Id of circle"
           }
         }
       },
@@ -248,6 +252,10 @@
           "thickness": {
             "type": "number",
             "description": "Stroke thickness in pixels"
+          },
+          "object_id": {
+            "type": "string",
+            "description": "Id of group points"
           }
         }
       },

--- a/schemas/jsonschema/PointsAnnotation.json
+++ b/schemas/jsonschema/PointsAnnotation.json
@@ -145,6 +145,10 @@
     "thickness": {
       "type": "number",
       "description": "Stroke thickness in pixels"
+    },
+    "object_id": {
+      "type": "string",
+      "description": "Id of group points"
     }
   }
 }

--- a/schemas/jsonschema/index.ts
+++ b/schemas/jsonschema/index.ts
@@ -264,6 +264,10 @@ export const CircleAnnotation = {
           "description": "Alpha value between 0 and 1"
         }
       }
+    },
+    "object_id": {
+      "type": "string",
+      "description": "Id of circle"
     }
   }
 };
@@ -985,6 +989,10 @@ export const ImageAnnotations = {
                 "description": "Alpha value between 0 and 1"
               }
             }
+          },
+          "object_id": {
+            "type": "string",
+            "description": "Id of circle"
           }
         }
       },
@@ -1138,6 +1146,10 @@ export const ImageAnnotations = {
           "thickness": {
             "type": "number",
             "description": "Stroke thickness in pixels"
+          },
+          "object_id": {
+            "type": "string",
+            "description": "Id of group points"
           }
         }
       },
@@ -4292,6 +4304,10 @@ export const PointsAnnotation = {
     "thickness": {
       "type": "number",
       "description": "Stroke thickness in pixels"
+    },
+    "object_id": {
+      "type": "string",
+      "description": "Id of group points"
     }
   }
 };

--- a/schemas/proto/foxglove/CircleAnnotation.proto
+++ b/schemas/proto/foxglove/CircleAnnotation.proto
@@ -27,4 +27,7 @@ message CircleAnnotation {
 
   // Outline color
   foxglove.Color outline_color = 6;
+
+  // Id of circle
+  string object_id = 7;
 }

--- a/schemas/proto/foxglove/PointsAnnotation.proto
+++ b/schemas/proto/foxglove/PointsAnnotation.proto
@@ -46,4 +46,7 @@ message PointsAnnotation {
 
   // Stroke thickness in pixels
   double thickness = 7;
+
+  // Id of group points
+  string object_id = 8;
 }

--- a/schemas/ros1/CircleAnnotation.msg
+++ b/schemas/ros1/CircleAnnotation.msg
@@ -20,3 +20,6 @@ foxglove_msgs/Color fill_color
 
 # Outline color
 foxglove_msgs/Color outline_color
+
+# Id of circle
+string object_id

--- a/schemas/ros1/PointsAnnotation.msg
+++ b/schemas/ros1/PointsAnnotation.msg
@@ -37,3 +37,6 @@ foxglove_msgs/Color fill_color
 
 # Stroke thickness in pixels
 float64 thickness
+
+# Id of group points
+string object_id

--- a/schemas/ros2/CircleAnnotation.msg
+++ b/schemas/ros2/CircleAnnotation.msg
@@ -20,3 +20,6 @@ foxglove_msgs/Color fill_color
 
 # Outline color
 foxglove_msgs/Color outline_color
+
+# Id of circle
+string object_id

--- a/schemas/ros2/PointsAnnotation.msg
+++ b/schemas/ros2/PointsAnnotation.msg
@@ -37,3 +37,6 @@ foxglove_msgs/Color fill_color
 
 # Stroke thickness in pixels
 float64 thickness
+
+# Id of group points
+string object_id

--- a/schemas/typescript/CircleAnnotation.ts
+++ b/schemas/typescript/CircleAnnotation.ts
@@ -23,4 +23,7 @@ export type CircleAnnotation = {
 
   /** Outline color */
   outline_color: Color;
+
+  /** Id of circle */
+  object_id: string;
 };

--- a/schemas/typescript/PointsAnnotation.ts
+++ b/schemas/typescript/PointsAnnotation.ts
@@ -27,4 +27,7 @@ export type PointsAnnotation = {
 
   /** Stroke thickness in pixels */
   thickness: number;
+
+  /** Id of group points */
+  object_id: string;
 };


### PR DESCRIPTION
I have added object_id in PointsAnnotation and CircleAnnotation.

### Description
I need this change because i want to have  possibility to send object id through protobuf message, in order  to be able to display it on ImageView. This is only the first part, the second is contained in foxglove/studio repo.

I will post here link of PR (the second part from foxglove/studio repo), for better understanding why i need this changes. 
https://github.com/foxglove/studio/pull/5921  

