### PR TITLE
Extending SceneEntity with object_id and pictogramUrl

### DIFF
--- a/internal/schemas.ts
+++ b/internal/schemas.ts
@@ -573,6 +573,16 @@ const SceneEntity: FoxgloveMessageSchema = {
         "Identifier for the entity. A entity will replace any prior entity on the same topic with the same `id`.",
     },
     {
+      name: "object_id",
+      type: { type: "primitive", name: "string" },
+      description: "id of object ",
+    },
+    {
+      name: "pictogramUrl",
+      type: { type: "primitive", name: "string" },
+      description: "Url of pictogram",
+    },
+    {
       name: "lifetime",
       type: { type: "primitive", name: "duration" },
       description:

--- a/ros_foxglove_msgs/ros1/SceneEntity.msg
+++ b/ros_foxglove_msgs/ros1/SceneEntity.msg
@@ -12,6 +12,12 @@ string frame_id
 # Identifier for the entity. A entity will replace any prior entity on the same topic with the same `id`.
 string id
 
+# id of object
+string object_id
+
+# Url of pictogram
+string pictogramUrl
+
 # Length of time (relative to `timestamp`) after which the entity should be automatically removed. Zero value indicates the entity should remain visible until it is replaced or deleted.
 duration lifetime
 

--- a/ros_foxglove_msgs/ros2/SceneEntity.msg
+++ b/ros_foxglove_msgs/ros2/SceneEntity.msg
@@ -12,6 +12,12 @@ string frame_id
 # Identifier for the entity. A entity will replace any prior entity on the same topic with the same `id`.
 string id
 
+# id of object
+string object_id
+
+# Url of pictogram
+string pictogramurl
+
 # Length of time (relative to `timestamp`) after which the entity should be automatically removed. Zero value indicates the entity should remain visible until it is replaced or deleted.
 builtin_interfaces/Duration lifetime
 

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -2296,6 +2296,32 @@ Identifier for the entity. A entity will replace any prior entity on the same to
 </td>
 </tr>
 <tr>
+<td><code>object_id</code></td>
+<td>
+
+string
+
+</td>
+<td>
+
+id of object 
+
+</td>
+</tr>
+<tr>
+<td><code>pictogramUrl</code></td>
+<td>
+
+string
+
+</td>
+<td>
+
+Url of pictogram
+
+</td>
+</tr>
+<tr>
 <td><code>lifetime</code></td>
 <td>
 

--- a/schemas/flatbuffer/SceneEntity.fbs
+++ b/schemas/flatbuffer/SceneEntity.fbs
@@ -25,6 +25,12 @@ table SceneEntity {
   /// Identifier for the entity. A entity will replace any prior entity on the same topic with the same `id`.
   id:string;
 
+  /// id of object
+  object_id:string;
+
+  /// Url of pictogram
+  pictogramurl:string;
+
   /// Length of time (relative to `timestamp`) after which the entity should be automatically removed. Zero value indicates the entity should remain visible until it is replaced or deleted.
   lifetime:Duration;
 

--- a/schemas/jsonschema/SceneEntity.json
+++ b/schemas/jsonschema/SceneEntity.json
@@ -28,6 +28,14 @@
       "type": "string",
       "description": "Identifier for the entity. A entity will replace any prior entity on the same topic with the same `id`."
     },
+    "object_id": {
+      "type": "string",
+      "description": "id of object "
+    },
+    "pictogramUrl": {
+      "type": "string",
+      "description": "Url of pictogram"
+    },
     "lifetime": {
       "type": "object",
       "title": "duration",

--- a/schemas/jsonschema/SceneUpdate.json
+++ b/schemas/jsonschema/SceneUpdate.json
@@ -82,6 +82,14 @@
             "type": "string",
             "description": "Identifier for the entity. A entity will replace any prior entity on the same topic with the same `id`."
           },
+          "object_id": {
+            "type": "string",
+            "description": "id of object "
+          },
+          "pictogramUrl": {
+            "type": "string",
+            "description": "Url of pictogram"
+          },
           "lifetime": {
             "type": "object",
             "title": "duration",

--- a/schemas/jsonschema/index.ts
+++ b/schemas/jsonschema/index.ts
@@ -1746,6 +1746,14 @@ export const SceneEntity = {
       "type": "string",
       "description": "Identifier for the entity. A entity will replace any prior entity on the same topic with the same `id`."
     },
+    "object_id": {
+      "type": "string",
+      "description": "id of object "
+    },
+    "pictogramUrl": {
+      "type": "string",
+      "description": "Url of pictogram"
+    },
     "lifetime": {
       "type": "object",
       "title": "duration",
@@ -2812,6 +2820,14 @@ export const SceneUpdate = {
           "id": {
             "type": "string",
             "description": "Identifier for the entity. A entity will replace any prior entity on the same topic with the same `id`."
+          },
+          "object_id": {
+            "type": "string",
+            "description": "id of object "
+          },
+          "pictogramUrl": {
+            "type": "string",
+            "description": "Url of pictogram"
           },
           "lifetime": {
             "type": "object",

--- a/schemas/proto/foxglove/SceneEntity.proto
+++ b/schemas/proto/foxglove/SceneEntity.proto
@@ -27,36 +27,42 @@ message SceneEntity {
   // Identifier for the entity. A entity will replace any prior entity on the same topic with the same `id`.
   string id = 3;
 
+  // id of object
+  string object_id = 4;
+
+  // Url of pictogram
+  string pictogramUrl = 5;
+
   // Length of time (relative to `timestamp`) after which the entity should be automatically removed. Zero value indicates the entity should remain visible until it is replaced or deleted.
-  google.protobuf.Duration lifetime = 4;
+  google.protobuf.Duration lifetime = 6;
 
   // Whether the entity should keep its location in the fixed frame (false) or follow the frame specified in `frame_id` as it moves relative to the fixed frame (true)
-  bool frame_locked = 5;
+  bool frame_locked = 7;
 
   // Additional user-provided metadata associated with the entity. Keys must be unique.
-  repeated foxglove.KeyValuePair metadata = 6;
+  repeated foxglove.KeyValuePair metadata = 8;
 
   // Arrow primitives
-  repeated foxglove.ArrowPrimitive arrows = 7;
+  repeated foxglove.ArrowPrimitive arrows = 9;
 
   // Cube primitives
-  repeated foxglove.CubePrimitive cubes = 8;
+  repeated foxglove.CubePrimitive cubes = 10;
 
   // Sphere primitives
-  repeated foxglove.SpherePrimitive spheres = 9;
+  repeated foxglove.SpherePrimitive spheres = 11;
 
   // Cylinder primitives
-  repeated foxglove.CylinderPrimitive cylinders = 10;
+  repeated foxglove.CylinderPrimitive cylinders = 12;
 
   // Line primitives
-  repeated foxglove.LinePrimitive lines = 11;
+  repeated foxglove.LinePrimitive lines = 13;
 
   // Triangle list primitives
-  repeated foxglove.TriangleListPrimitive triangles = 12;
+  repeated foxglove.TriangleListPrimitive triangles = 14;
 
   // Text primitives
-  repeated foxglove.TextPrimitive texts = 13;
+  repeated foxglove.TextPrimitive texts = 15;
 
   // Model primitives
-  repeated foxglove.ModelPrimitive models = 14;
+  repeated foxglove.ModelPrimitive models = 16;
 }

--- a/schemas/ros1/SceneEntity.msg
+++ b/schemas/ros1/SceneEntity.msg
@@ -12,6 +12,12 @@ string frame_id
 # Identifier for the entity. A entity will replace any prior entity on the same topic with the same `id`.
 string id
 
+# id of object
+string object_id
+
+# Url of pictogram
+string pictogramUrl
+
 # Length of time (relative to `timestamp`) after which the entity should be automatically removed. Zero value indicates the entity should remain visible until it is replaced or deleted.
 duration lifetime
 

--- a/schemas/ros2/SceneEntity.msg
+++ b/schemas/ros2/SceneEntity.msg
@@ -12,6 +12,12 @@ string frame_id
 # Identifier for the entity. A entity will replace any prior entity on the same topic with the same `id`.
 string id
 
+# id of object
+string object_id
+
+# Url of pictogram
+string pictogramurl
+
 # Length of time (relative to `timestamp`) after which the entity should be automatically removed. Zero value indicates the entity should remain visible until it is replaced or deleted.
 builtin_interfaces/Duration lifetime
 

--- a/schemas/typescript/SceneEntity.ts
+++ b/schemas/typescript/SceneEntity.ts
@@ -23,6 +23,12 @@ export type SceneEntity = {
   /** Identifier for the entity. A entity will replace any prior entity on the same topic with the same `id`. */
   id: string;
 
+  /** id of object  */
+  object_id: string;
+
+  /** Url of pictogram */
+  pictogramUrl: string;
+
   /** Length of time (relative to `timestamp`) after which the entity should be automatically removed. Zero value indicates the entity should remain visible until it is replaced or deleted. */
   lifetime: Duration;
 


### PR DESCRIPTION
I have added  object_id and pictogramUrl in SceneEntity.

### Description
I need this change because i want to have possibility to send object id and pictogram URL through protobuf message, in order to be able to display it on 3DView.This pictogram will closer describe object in 3DView(e.g. one image of car for all type of cars in view). The same is for object id(e.g. text  car for all type of cars, text truck for all type of truck)  This is only the first part, the second (displaying on 3DView) is contained in foxglove/studio repo.
