### PR TITLE
Do not normalize time/duration types in generateRosMsgDefinition

### DIFF
--- a/internal/generateRos.test.ts
+++ b/internal/generateRos.test.ts
@@ -239,7 +239,7 @@ describe("generateRosMsgDefinition", () => {
             "isArray": false,
             "isComplex": false,
             "name": "field_duration",
-            "type": "builtin_interfaces/Duration",
+            "type": "duration",
           },
           {
             "arrayLength": undefined,
@@ -247,7 +247,7 @@ describe("generateRosMsgDefinition", () => {
             "isArray": false,
             "isComplex": false,
             "name": "field_time",
-            "type": "builtin_interfaces/Time",
+            "type": "time",
           },
           {
             "arrayLength": undefined,
@@ -295,7 +295,7 @@ describe("generateRosMsgDefinition", () => {
             "isArray": true,
             "isComplex": false,
             "name": "field_duration_array",
-            "type": "builtin_interfaces/Duration",
+            "type": "duration",
           },
           {
             "arrayLength": undefined,
@@ -303,7 +303,7 @@ describe("generateRosMsgDefinition", () => {
             "isArray": true,
             "isComplex": false,
             "name": "field_time_array",
-            "type": "builtin_interfaces/Time",
+            "type": "time",
           },
           {
             "arrayLength": undefined,
@@ -343,7 +343,7 @@ describe("generateRosMsgDefinition", () => {
             "isArray": true,
             "isComplex": false,
             "name": "field_duration_fixed_array",
-            "type": "builtin_interfaces/Duration",
+            "type": "duration",
           },
           {
             "arrayLength": 3,
@@ -351,7 +351,7 @@ describe("generateRosMsgDefinition", () => {
             "isArray": true,
             "isComplex": false,
             "name": "field_time_fixed_array",
-            "type": "builtin_interfaces/Time",
+            "type": "time",
           },
           {
             "arrayLength": 3,
@@ -454,6 +454,7 @@ describe("generateRosMsg", () => {
         generateRosMsgDefinition(exampleMessageWithoutArrayOfBytes, {
           rosVersion: 1,
         }),
+        { rosVersion: 1 },
       ),
     ).toMatchInlineSnapshot(`
       "# foxglove_msgs/ExampleMessage
@@ -550,6 +551,7 @@ describe("generateRosMsg", () => {
         generateRosMsgDefinition(exampleMessageWithoutArrayOfBytes, {
           rosVersion: 2,
         }),
+        { rosVersion: 2 },
       ),
     ).toMatchInlineSnapshot(`
       "# foxglove_msgs/msg/ExampleMessage

--- a/internal/generateRos.ts
+++ b/internal/generateRos.ts
@@ -70,7 +70,7 @@ export function generateRosMsg(
       constant = `=${field.valueText}`;
     }
     let type = field.type;
-    if (!(field.isComplex ?? false) && ("time" === type || "duration" === type)) {
+    if (type === "time" || type === "duration") {
       type = timeDurationToRos(type, { rosVersion });
     }
     source += `${type}${field.isArray === true ? `[${field.arrayLength ?? ""}]` : ""} ${

--- a/internal/generateRos.ts
+++ b/internal/generateRos.ts
@@ -17,8 +17,7 @@ type RosMsgDefinitionWithDescription = {
 };
 
 function primitiveToRos(
-  type: Exclude<FoxglovePrimitive, "uint32" | "bytes">,
-  { rosVersion }: { rosVersion: 1 | 2 },
+  type: Exclude<FoxglovePrimitive, "uint32" | "bytes" | "time" | "duration">,
 ) {
   switch (type) {
     case "string":
@@ -27,14 +26,21 @@ function primitiveToRos(
       return "bool";
     case "float64":
       return "float64";
-    case "time":
-      return rosVersion === 2 ? "builtin_interfaces/Time" : "time";
-    case "duration":
-      return rosVersion === 2 ? "builtin_interfaces/Duration" : "duration";
   }
 }
 
-export function generateRosMsg(def: RosMsgDefinitionWithDescription): string {
+function timeDurationToRos(type: "time" | "duration", { rosVersion }: { rosVersion: 1 | 2 }) {
+  if (type === "time") {
+    return rosVersion === 2 ? "builtin_interfaces/Time" : "time";
+  } else {
+    return rosVersion === 2 ? "builtin_interfaces/Duration" : "duration";
+  }
+}
+
+export function generateRosMsg(
+  def: RosMsgDefinitionWithDescription,
+  { rosVersion }: { rosVersion: 1 | 2 },
+): string {
   let source = "";
   source += `# ${def.rosFullInterfaceName}\n`;
   if (def.description != undefined) {
@@ -63,7 +69,11 @@ export function generateRosMsg(def: RosMsgDefinitionWithDescription): string {
       }
       constant = `=${field.valueText}`;
     }
-    source += `${field.type}${field.isArray === true ? `[${field.arrayLength ?? ""}]` : ""} ${
+    let type = field.type;
+    if (!(field.isComplex ?? false) && ("time" === type || "duration" === type)) {
+      type = timeDurationToRos(type, { rosVersion });
+    }
+    source += `${type}${field.isArray === true ? `[${field.arrayLength ?? ""}]` : ""} ${
       field.name
     }${constant}\n`;
   }
@@ -169,8 +179,12 @@ export function generateRosMsgDefinition(
           isArray = true;
         } else if (field.type.name === "uint32") {
           fieldType = "uint32";
+        } else if (field.type.name === "time") {
+          fieldType = "time";
+        } else if (field.type.name === "duration") {
+          fieldType = "duration";
         } else {
-          fieldType = primitiveToRos(field.type.name, { rosVersion });
+          fieldType = primitiveToRos(field.type.name);
         }
         break;
     }
@@ -205,22 +219,25 @@ export function generateRosMsgMergedSchema(
     }
   }
 
-  let result = generateRosMsg(generateRosMsgDefinition(schema, { rosVersion }));
+  let result = generateRosMsg(generateRosMsgDefinition(schema, { rosVersion }), { rosVersion });
   for (const dep of dependencies) {
     let name: string;
     let source: string;
     if (dep.type === "ros") {
       name = dep.name;
-      source = generateRosMsg({
-        originalName: dep.name,
-        rosMsgInterfaceName: dep.name,
-        rosFullInterfaceName: dep.name,
-        fields: ros1[dep.name].definitions,
-      });
+      source = generateRosMsg(
+        {
+          originalName: dep.name,
+          rosMsgInterfaceName: dep.name,
+          rosFullInterfaceName: dep.name,
+          fields: ros1[dep.name].definitions,
+        },
+        { rosVersion },
+      );
     } else {
       const definition = generateRosMsgDefinition(dep.schema, { rosVersion });
       name = definition.rosMsgInterfaceName;
-      source = generateRosMsg(definition);
+      source = generateRosMsg(definition, { rosVersion });
     }
     result += `================================================================================\nMSG: ${name}\n${source}`;
   }

--- a/scripts/updateGeneratedFiles.ts
+++ b/scripts/updateGeneratedFiles.ts
@@ -45,7 +45,9 @@ async function main({ outDir, rosOutDir }: { outDir: string; rosOutDir: string }
       if (schema.rosEquivalent != undefined) {
         continue;
       }
-      const msg = generateRosMsg(generateRosMsgDefinition(schema, { rosVersion: 1 }));
+      const msg = generateRosMsg(generateRosMsgDefinition(schema, { rosVersion: 1 }), {
+        rosVersion: 1,
+      });
       await fs.writeFile(path.join(outDir, "ros1", `${schema.name}.msg`), msg);
       await fs.writeFile(path.join(rosOutDir, "ros1", `${schema.name}.msg`), msg);
     }
@@ -58,7 +60,9 @@ async function main({ outDir, rosOutDir }: { outDir: string; rosOutDir: string }
       if (schema.rosEquivalent != undefined) {
         continue;
       }
-      const msg = generateRosMsg(generateRosMsgDefinition(schema, { rosVersion: 2 }));
+      const msg = generateRosMsg(generateRosMsgDefinition(schema, { rosVersion: 2 }), {
+        rosVersion: 2,
+      });
       await fs.writeFile(path.join(outDir, "ros2", `${schema.name}.msg`), msg);
       await fs.writeFile(path.join(rosOutDir, "ros2", `${schema.name}.msg`), msg);
     }


### PR DESCRIPTION
### Public-Facing Changes

Do not normalize `time` & `duration` types in `generateRosMsgDefinition`

### Description
Changes `generateRosMsgDefinition` to not normalize `time` & `duration` fields to their ROS2 equivalents (e.g. `builtin_interfaces/Time`). This is now done in `generateRosMsg` as `generateRosMsgDefinition` should output a message definition which is compliant with [@foxglove/message-definition](https://github.com/foxglove/message-definition) where e.g. `builtin_interfaces/Time` does not exist.

See https://github.com/foxglove/rosmsg2-serialization/pull/17#issuecomment-1608102161