### PR TITLE
Fix import error by requiring at least python `protobuf>=3.20.0`

### DIFF
--- a/python/foxglove-schemas-protobuf/setup.cfg
+++ b/python/foxglove-schemas-protobuf/setup.cfg
@@ -12,7 +12,7 @@ classifiers =
 
 [options]
 install_requires = 
-    protobuf
+    protobuf>=3.20.0
 install_package_data = True
 packages = find:
 python_requires = >=3.7


### PR DESCRIPTION


### Public-Facing Changes

Fix import error by requiring at least python `protobuf>=3.20.0`

### Description
See #113 for details.

Fixes #113
