### PR TITLE
Add Time type to exports for typescript types

### DIFF
--- a/internal/exportTypeScriptSchemas.ts
+++ b/internal/exportTypeScriptSchemas.ts
@@ -4,7 +4,7 @@ import {
   TIME_TS,
   generateTypeScript,
 } from "./generateTypeScript";
-import { foxgloveEnumSchemas, foxgloveMessageSchemas } from "./schemas";
+import { foxgloveEnumSchemas, foxgloveMessageSchemas, foxglovePrimitiveSchemas } from "./schemas";
 
 /**
  * Export schemas as TypeScript source code, keyed by the file base name (without `.ts` suffix).
@@ -30,6 +30,7 @@ export function exportTypeScriptSchemas(
   const allSchemaNames = [
     ...Object.values(foxgloveMessageSchemas),
     ...Object.values(foxgloveEnumSchemas),
+    ...Object.values(foxglovePrimitiveSchemas),
   ].sort((a, b) => a.name.localeCompare(b.name));
   let indexTS = "";
   for (const schema of allSchemaNames) {

--- a/internal/exportTypeScriptSchemas.ts
+++ b/internal/exportTypeScriptSchemas.ts
@@ -1,9 +1,4 @@
-import {
-  DURATION_TS,
-  GenerateTypeScriptOptions,
-  TIME_TS,
-  generateTypeScript,
-} from "./generateTypeScript";
+import { GenerateTypeScriptOptions, generateTypeScript } from "./generateTypeScript";
 import { foxgloveEnumSchemas, foxgloveMessageSchemas, foxglovePrimitiveSchemas } from "./schemas";
 
 /**
@@ -24,8 +19,9 @@ export function exportTypeScriptSchemas(
     schemas.set(schema.name, generateTypeScript(schema, options));
   }
 
-  schemas.set("Duration", DURATION_TS);
-  schemas.set("Time", TIME_TS);
+  for (const schema of Object.values(foxglovePrimitiveSchemas)) {
+    schemas.set(schema.name, generateTypeScript(schema, options));
+  }
 
   const allSchemaNames = [
     ...Object.values(foxgloveMessageSchemas),

--- a/internal/generateFlatbufferSchema.ts
+++ b/internal/generateFlatbufferSchema.ts
@@ -74,6 +74,17 @@ export function generateFlatbuffers(
   let definition;
   const imports = new Set<string>();
   switch (schema.type) {
+    case "primitive":
+      definition = "";
+      if (schema.name === "Time") {
+        definition = TIME_FB;
+      } else if (schema.name === "Duration") {
+        definition = DURATION_FB;
+      }
+      if (definition === "") {
+        throw new Error(`Flatbuffer encountered an unexpected type: ${schema.name}`);
+      }
+      return definition;
     case "enum": {
       const fields = schema.values.map(({ name, value, description }) => {
         if (description != undefined) {

--- a/internal/generateOmgIdl.ts
+++ b/internal/generateOmgIdl.ts
@@ -42,6 +42,20 @@ export function generateOmgIdl(schema: FoxgloveSchema): string {
 
   let definition: string;
   switch (schema.type) {
+    case "primitive":
+      {
+        definition = "";
+        if (schema.name === "Time") {
+          definition = TIME_IDL;
+        } else if (schema.name === "Duration") {
+          definition = DURATION_IDL;
+        }
+        if (definition === "") {
+          throw new Error(`Flatbuffer encountered an unexpected type: ${schema.name}`);
+        }
+        return definition;
+      }
+      break;
     case "enum": {
       const fields = schema.values.map(({ name, value, description }, index) => {
         const separator = index === schema.values.length - 1 ? "" : ",";

--- a/internal/generateTypeScript.ts
+++ b/internal/generateTypeScript.ts
@@ -57,6 +57,19 @@ export function generateTypeScript(
 
   let definition: string;
   switch (schema.type) {
+    case "primitive":
+      definition = "";
+      if (schema.name === "Time") {
+        definition = TIME_TS;
+      } else if (schema.name === "Duration") {
+        definition = DURATION_TS;
+      }
+      if (definition === "") {
+        throw new Error(
+          `TypeScriptGenerator encountered an unexpected primitive type ${schema.name}`,
+        );
+      }
+      return definition;
     case "enum": {
       const fields = schema.values.map(({ name, value, description }) => {
         if (description != undefined) {

--- a/internal/schemas.ts
+++ b/internal/schemas.ts
@@ -1,4 +1,4 @@
-import { FoxgloveEnumSchema, FoxgloveMessageSchema } from "./types";
+import { FoxgloveEnumSchema, FoxgloveMessageSchema, FoxglovePrimitiveSchema } from "./types";
 
 const Color: FoxgloveMessageSchema = {
   type: "message",
@@ -1464,8 +1464,8 @@ const Time: FoxglovePrimitiveSchema = {
       type: { type: "primitive", name: "float64" },
       description: "nanoseconds",
     },
-  ]
-}
+  ],
+};
 
 const Duration: FoxglovePrimitiveSchema = {
   type: "primitive",
@@ -1482,14 +1482,13 @@ const Duration: FoxglovePrimitiveSchema = {
       type: { type: "primitive", name: "float64" },
       description: "nanoseconds",
     },
-  ]
-}
-
-export const foxglovePrimitiveSchemas = {
-  time: Time,
-  duration: Duration,
+  ],
 };
 
+export const foxglovePrimitiveSchemas = {
+  Time,
+  Duration,
+};
 
 export const foxgloveMessageSchemas = {
   ArrowPrimitive,

--- a/internal/schemas.ts
+++ b/internal/schemas.ts
@@ -1449,6 +1449,48 @@ const LaserScan: FoxgloveMessageSchema = {
   ],
 };
 
+const Time: FoxglovePrimitiveSchema = {
+  type: "primitive",
+  name: "time",
+  description: "Timestamp in the format of second and nanoseconds since epoch",
+  fields: [
+    {
+      name: "sec",
+      type: { type: "primitive", name: "float64" },
+      description: "Seconds since epoch",
+    },
+    {
+      name: "nsec",
+      type: { type: "primitive", name: "float64" },
+      description: "nanoseconds",
+    },
+  ]
+}
+
+const Duration: FoxglovePrimitiveSchema = {
+  type: "primitive",
+  name: "time",
+  description: "Difference between two timestamps",
+  fields: [
+    {
+      name: "sec",
+      type: { type: "primitive", name: "float64" },
+      description: "Seconds since epoch",
+    },
+    {
+      name: "nsec",
+      type: { type: "primitive", name: "float64" },
+      description: "nanoseconds",
+    },
+  ]
+}
+
+export const foxglovePrimitiveSchemas = {
+  time: Time,
+  duration: Duration,
+};
+
+
 export const foxgloveMessageSchemas = {
   ArrowPrimitive,
   CameraCalibration,

--- a/internal/types.ts
+++ b/internal/types.ts
@@ -12,7 +12,7 @@ export type FoxglovePrimitiveSchema = {
   name: string;
   description: string;
   fields: ReadonlyArray<FoxglovePrimitive>;
-}
+};
 
 export type FoxgloveEnumSchema = {
   type: "enum";

--- a/internal/types.ts
+++ b/internal/types.ts
@@ -7,6 +7,13 @@ export type FoxglovePrimitive =
   | "time"
   | "duration";
 
+export type FoxglovePrimitiveSchema = {
+  type: "primitive";
+  name: string;
+  description: string;
+  fields: ReadonlyArray<FoxglovePrimitive>;
+}
+
 export type FoxgloveEnumSchema = {
   type: "enum";
   name: string;
@@ -41,4 +48,4 @@ export type FoxgloveMessageSchema = {
   fields: ReadonlyArray<FoxgloveMessageField>;
 };
 
-export type FoxgloveSchema = FoxgloveMessageSchema | FoxgloveEnumSchema;
+export type FoxgloveSchema = FoxgloveMessageSchema | FoxgloveEnumSchema | FoxglovePrimitiveSchema;

--- a/schemas/typescript/index.ts
+++ b/schemas/typescript/index.ts
@@ -39,6 +39,7 @@ export * from "./SceneUpdate";
 export * from "./SpherePrimitive";
 export * from "./TextAnnotation";
 export * from "./TextPrimitive";
+export * from "./Time";
 export * from "./TriangleListPrimitive";
 export * from "./Vector2";
 export * from "./Vector3";

--- a/schemas/typescript/index.ts
+++ b/schemas/typescript/index.ts
@@ -39,7 +39,6 @@ export * from "./SceneUpdate";
 export * from "./SpherePrimitive";
 export * from "./TextAnnotation";
 export * from "./TextPrimitive";
-export * from "./Time";
 export * from "./TriangleListPrimitive";
 export * from "./Vector2";
 export * from "./Vector3";


### PR DESCRIPTION
### Public-Facing Changes

Adds export of the Time type for typescript type

### Description

As far as I can see there is no reason for the Time type not to be exported. Exporting it is a quality of development improvement when writing plugins relying on timestamps used in the other exported types.
