### PR TITLE
Improve doc on PointAnnotation field `outline_color`

### DIFF
--- a/internal/schemas.ts
+++ b/internal/schemas.ts
@@ -1159,7 +1159,7 @@ const PointsAnnotation: FoxgloveMessageSchema = {
       name: "outline_colors",
       type: { type: "nested", schema: Color },
       description:
-        "Per-point colors, if `type` is `POINTS`, or per-segment stroke colors, if `type` is `LINE_LIST`.",
+        "Per-point colors, if `type` is `POINTS`, or per-segment stroke colors, if `type` is `LINE_LIST`, `LINE_STRIP` or `LINE_LOOP`.",
       array: true,
     },
     {


### PR DESCRIPTION
### Public-Facing Changes
Improve doc on PointAnnotation field `outline_color`

### Description
Clarifies that the `outline_color` can also be used to set the segment colors for `LINE_STRIP` and `LINE_LOOP` types.

Related to https://github.com/foxglove/studio/pull/6973