### PR TITLE
Update links and studio references

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,6 +175,11 @@ jobs:
         run: |
           sudo pip install pydocstyle==6.1.1
 
+      - name: Downgrade pytest as a workaround for https://github.com/scientific-python/pytest-doctestplus/issues/240
+        if: ${{ matrix.ros_version == 'humble' || matrix.ros_version == 'iron' || matrix.ros_version == 'rolling' }}
+        run: |
+          sudo pip install pytest==8.0.2
+
       - name: build and test ros2
         if: ${{ matrix.ros_version == 2 }}
         uses: ros-tooling/action-ros-ci@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,7 +176,7 @@ jobs:
           sudo pip install pydocstyle==6.1.1
 
       - name: Downgrade pytest as a workaround for https://github.com/scientific-python/pytest-doctestplus/issues/240
-        if: ${{ matrix.ros_version == 'humble' || matrix.ros_version == 'iron' || matrix.ros_version == 'rolling' }}
+        if: ${{ matrix.ros_distribution == 'humble' || matrix.ros_distribution == 'iron' || matrix.ros_distribution == 'rolling' }}
         run: |
           sudo pip install pytest==8.0.2
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 // -*- jsonc -*-
 {
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true,
@@ -18,12 +18,8 @@
   },
   "jest.jestCommandLine": "yarn test",
 
-  "python.formatting.provider": "black",
   "python.analysis.typeCheckingMode": "strict",
-  "python.linting.flake8Enabled": true,
-  "python.linting.enabled": true,
-  "python.linting.flake8Args": ["--config", "python/.flake8"],
   "[python]": {
-    "editor.defaultFormatter": "ms-python.python"
+    "editor.defaultFormatter": "ms-python.black-formatter"
   }
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # @foxglove/schemas
 
-Message schemas supported by [Foxglove Studio](https://studio.foxglove.dev)
+Message schemas supported by [Foxglove](https://foxglove.dev)
 
 | Language/Framework    | Package name                  | Version                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
 | --------------------- | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -11,11 +11,11 @@ Message schemas supported by [Foxglove Studio](https://studio.foxglove.dev)
 
 ## Introduction
 
-See [Foxglove Schemas documentation](https://foxglove.dev/docs/studio/messages).
+See [Foxglove Schemas documentation](https://docs.foxglove.dev/docs/visualization/message-schemas/introduction).
 
 The [schemas](./schemas) folder contains type definitions generated for ROS 1, ROS 2, Protobuf, JSON Schema, TypeScript, and OMG IDL.
 
-These schemas can be used in [MCAP](https://github.com/foxglove/mcap) files or [Foxglove WebSocket](https://github.com/foxglove/ws-protocol) servers to take advantage of Foxglove Studio's visualizations.
+These schemas can be used in [MCAP](https://github.com/foxglove/mcap) files or [Foxglove WebSocket](https://github.com/foxglove/ws-protocol) servers to take advantage of Foxglove's visualizations.
 
 ## License
 

--- a/internal/__snapshots__/exportTypeScriptSchemas.test.ts.snap
+++ b/internal/__snapshots__/exportTypeScriptSchemas.test.ts.snap
@@ -200,7 +200,7 @@ export type CompressedVideo = {
   /**
    * Compressed video frame data.
    * 
-   * For packet-based video codecs this data must begin and end on packet boundaries (no partial packets), and must contain enough video packets to decode exactly one image (either a keyframe or delta frame). Note: Foxglove Studio does not support video streams that include B frames because they require lookahead.
+   * For packet-based video codecs this data must begin and end on packet boundaries (no partial packets), and must contain enough video packets to decode exactly one image (either a keyframe or delta frame). Note: Foxglove does not support video streams that include B frames because they require lookahead.
    */
   data: Uint8Array;
 

--- a/internal/generateMarkdown.ts
+++ b/internal/generateMarkdown.ts
@@ -11,7 +11,7 @@ export function generateMarkdown(
     `\
 # Foxglove schemas
 
-See [Foxglove Schemas documentation](https://foxglove.dev/docs/studio/messages).
+See [Foxglove Schemas documentation](https://docs.foxglove.dev/docs/visualization/message-schemas/introduction).
 
 All schemas are generated from [schemas.ts](/internal/schemas.ts).`,
 

--- a/internal/generateRos.ts
+++ b/internal/generateRos.ts
@@ -127,8 +127,8 @@ export function generateRosMsgDefinition(
     let fieldType: string;
     switch (field.type.type) {
       case "enum": {
-        // Add enum constants preceding the field so that Studio can pick them up:
-        // https://foxglove.dev/docs/studio/annotating-data
+        // Add enum constants preceding the field so that Foxglove can pick them up:
+        // https://docs.foxglove.dev/docs/visualization/annotate-ros-enum-fields
         const enumName = field.type.enum.name;
         const valueType = "uint8";
         fieldType = valueType;

--- a/internal/generateTypeScript.ts
+++ b/internal/generateTypeScript.ts
@@ -44,7 +44,7 @@ export const DURATION_TS = `export type Duration = {
 export type GenerateTypeScriptOptions = {
   /**
    * Include TypedArray types on numeric array fields, e.g. `number[] | Uint32Array`. Used by
-   * foxglove/studio to accept TypedArrays for user script outputs.
+   * Foxglove to accept TypedArrays for user script outputs.
    */
   includeTypedArrays?: boolean;
 };

--- a/internal/schemas.ts
+++ b/internal/schemas.ts
@@ -811,7 +811,7 @@ const CompressedVideo: FoxgloveMessageSchema = {
       name: "data",
       type: { type: "primitive", name: "bytes" },
       description:
-        "Compressed video frame data.\n\nFor packet-based video codecs this data must begin and end on packet boundaries (no partial packets), and must contain enough video packets to decode exactly one image (either a keyframe or delta frame). Note: Foxglove Studio does not support video streams that include B frames because they require lookahead.",
+        "Compressed video frame data.\n\nFor packet-based video codecs this data must begin and end on packet boundaries (no partial packets), and must contain enough video packets to decode exactly one image (either a keyframe or delta frame). Note: Foxglove does not support video streams that include B frames because they require lookahead.",
     },
     {
       name: "format",

--- a/python/foxglove-schemas-flatbuffer/README.md
+++ b/python/foxglove-schemas-flatbuffer/README.md
@@ -1,6 +1,6 @@
 # Foxglove Schemas (Flatbuffer)
 
-This package provides [Flatbuffer](https://google.github.io/flatbuffers/) classes for [Foxglove Schemas](https://foxglove.dev/docs/studio/messages/introduction).
+This package provides [Flatbuffer](https://google.github.io/flatbuffers/) classes for [Foxglove Schemas](https://docs.foxglove.dev/docs/visualization/message-schemas/introduction).
 
 ## Installation
 

--- a/python/foxglove-schemas-protobuf/README.md
+++ b/python/foxglove-schemas-protobuf/README.md
@@ -1,6 +1,6 @@
 # Foxglove Schemas (Protobuf)
 
-This package provides [Protobuf](https://developers.google.com/protocol-buffers/) classes for [Foxglove Schemas](https://foxglove.dev/docs/studio/messages/introduction).
+This package provides [Protobuf](https://developers.google.com/protocol-buffers/) classes for [Foxglove Schemas](https://docs.foxglove.dev/docs/visualization/message-schemas/introduction).
 
 ## Installation
 

--- a/ros_foxglove_msgs/package.xml
+++ b/ros_foxglove_msgs/package.xml
@@ -4,7 +4,7 @@
   <name>foxglove_msgs</name>
   <version>3.0.0</version>
   <description>
-    foxglove_msgs provides visualization messages that are supported by Foxglove Studio.
+    foxglove_msgs provides visualization messages that are supported by Foxglove.
   </description>
   <maintainer email="ros-tooling@foxglove.dev">Foxglove</maintainer>
   <license>MIT</license>

--- a/ros_foxglove_msgs/ros1/CompressedVideo.msg
+++ b/ros_foxglove_msgs/ros1/CompressedVideo.msg
@@ -13,7 +13,7 @@ string frame_id
 
 # Compressed video frame data.
 # 
-# For packet-based video codecs this data must begin and end on packet boundaries (no partial packets), and must contain enough video packets to decode exactly one image (either a keyframe or delta frame). Note: Foxglove Studio does not support video streams that include B frames because they require lookahead.
+# For packet-based video codecs this data must begin and end on packet boundaries (no partial packets), and must contain enough video packets to decode exactly one image (either a keyframe or delta frame). Note: Foxglove does not support video streams that include B frames because they require lookahead.
 uint8[] data
 
 # Video format.

--- a/ros_foxglove_msgs/ros2/CompressedVideo.msg
+++ b/ros_foxglove_msgs/ros2/CompressedVideo.msg
@@ -13,7 +13,7 @@ string frame_id
 
 # Compressed video frame data.
 # 
-# For packet-based video codecs this data must begin and end on packet boundaries (no partial packets), and must contain enough video packets to decode exactly one image (either a keyframe or delta frame). Note: Foxglove Studio does not support video streams that include B frames because they require lookahead.
+# For packet-based video codecs this data must begin and end on packet boundaries (no partial packets), and must contain enough video packets to decode exactly one image (either a keyframe or delta frame). Note: Foxglove does not support video streams that include B frames because they require lookahead.
 uint8[] data
 
 # Video format.

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -1,6 +1,6 @@
 # Foxglove schemas
 
-See [Foxglove Schemas documentation](https://foxglove.dev/docs/studio/messages).
+See [Foxglove Schemas documentation](https://docs.foxglove.dev/docs/visualization/message-schemas/introduction).
 
 All schemas are generated from [schemas.ts](/internal/schemas.ts).
 
@@ -664,7 +664,7 @@ bytes
 
 Compressed video frame data.
 
-For packet-based video codecs this data must begin and end on packet boundaries (no partial packets), and must contain enough video packets to decode exactly one image (either a keyframe or delta frame). Note: Foxglove Studio does not support video streams that include B frames because they require lookahead.
+For packet-based video codecs this data must begin and end on packet boundaries (no partial packets), and must contain enough video packets to decode exactly one image (either a keyframe or delta frame). Note: Foxglove does not support video streams that include B frames because they require lookahead.
 
 </td>
 </tr>

--- a/schemas/flatbuffer/CompressedVideo.fbs
+++ b/schemas/flatbuffer/CompressedVideo.fbs
@@ -16,7 +16,7 @@ table CompressedVideo {
 
   /// Compressed video frame data.
   /// 
-  /// For packet-based video codecs this data must begin and end on packet boundaries (no partial packets), and must contain enough video packets to decode exactly one image (either a keyframe or delta frame). Note: Foxglove Studio does not support video streams that include B frames because they require lookahead.
+  /// For packet-based video codecs this data must begin and end on packet boundaries (no partial packets), and must contain enough video packets to decode exactly one image (either a keyframe or delta frame). Note: Foxglove does not support video streams that include B frames because they require lookahead.
   data:[uint8];
 
   /// Video format.

--- a/schemas/jsonschema/CompressedVideo.json
+++ b/schemas/jsonschema/CompressedVideo.json
@@ -27,7 +27,7 @@
     "data": {
       "type": "string",
       "contentEncoding": "base64",
-      "description": "Compressed video frame data.\n\nFor packet-based video codecs this data must begin and end on packet boundaries (no partial packets), and must contain enough video packets to decode exactly one image (either a keyframe or delta frame). Note: Foxglove Studio does not support video streams that include B frames because they require lookahead."
+      "description": "Compressed video frame data.\n\nFor packet-based video codecs this data must begin and end on packet boundaries (no partial packets), and must contain enough video packets to decode exactly one image (either a keyframe or delta frame). Note: Foxglove does not support video streams that include B frames because they require lookahead."
     },
     "format": {
       "type": "string",

--- a/schemas/jsonschema/index.ts
+++ b/schemas/jsonschema/index.ts
@@ -360,7 +360,7 @@ export const CompressedVideo = {
     "data": {
       "type": "string",
       "contentEncoding": "base64",
-      "description": "Compressed video frame data.\n\nFor packet-based video codecs this data must begin and end on packet boundaries (no partial packets), and must contain enough video packets to decode exactly one image (either a keyframe or delta frame). Note: Foxglove Studio does not support video streams that include B frames because they require lookahead."
+      "description": "Compressed video frame data.\n\nFor packet-based video codecs this data must begin and end on packet boundaries (no partial packets), and must contain enough video packets to decode exactly one image (either a keyframe or delta frame). Note: Foxglove does not support video streams that include B frames because they require lookahead."
     },
     "format": {
       "type": "string",

--- a/schemas/omgidl/foxglove/CompressedVideo.idl
+++ b/schemas/omgidl/foxglove/CompressedVideo.idl
@@ -16,7 +16,7 @@ struct CompressedVideo {
 
   // Compressed video frame data.
   // 
-  // For packet-based video codecs this data must begin and end on packet boundaries (no partial packets), and must contain enough video packets to decode exactly one image (either a keyframe or delta frame). Note: Foxglove Studio does not support video streams that include B frames because they require lookahead.
+  // For packet-based video codecs this data must begin and end on packet boundaries (no partial packets), and must contain enough video packets to decode exactly one image (either a keyframe or delta frame). Note: Foxglove does not support video streams that include B frames because they require lookahead.
   sequence<uint8> data;
 
   // Video format.

--- a/schemas/proto/foxglove/CompressedVideo.proto
+++ b/schemas/proto/foxglove/CompressedVideo.proto
@@ -18,7 +18,7 @@ message CompressedVideo {
 
   // Compressed video frame data.
   // 
-  // For packet-based video codecs this data must begin and end on packet boundaries (no partial packets), and must contain enough video packets to decode exactly one image (either a keyframe or delta frame). Note: Foxglove Studio does not support video streams that include B frames because they require lookahead.
+  // For packet-based video codecs this data must begin and end on packet boundaries (no partial packets), and must contain enough video packets to decode exactly one image (either a keyframe or delta frame). Note: Foxglove does not support video streams that include B frames because they require lookahead.
   bytes data = 3;
 
   // Video format.

--- a/schemas/ros1/CompressedVideo.msg
+++ b/schemas/ros1/CompressedVideo.msg
@@ -13,7 +13,7 @@ string frame_id
 
 # Compressed video frame data.
 # 
-# For packet-based video codecs this data must begin and end on packet boundaries (no partial packets), and must contain enough video packets to decode exactly one image (either a keyframe or delta frame). Note: Foxglove Studio does not support video streams that include B frames because they require lookahead.
+# For packet-based video codecs this data must begin and end on packet boundaries (no partial packets), and must contain enough video packets to decode exactly one image (either a keyframe or delta frame). Note: Foxglove does not support video streams that include B frames because they require lookahead.
 uint8[] data
 
 # Video format.

--- a/schemas/ros2/CompressedVideo.msg
+++ b/schemas/ros2/CompressedVideo.msg
@@ -13,7 +13,7 @@ string frame_id
 
 # Compressed video frame data.
 # 
-# For packet-based video codecs this data must begin and end on packet boundaries (no partial packets), and must contain enough video packets to decode exactly one image (either a keyframe or delta frame). Note: Foxglove Studio does not support video streams that include B frames because they require lookahead.
+# For packet-based video codecs this data must begin and end on packet boundaries (no partial packets), and must contain enough video packets to decode exactly one image (either a keyframe or delta frame). Note: Foxglove does not support video streams that include B frames because they require lookahead.
 uint8[] data
 
 # Video format.

--- a/schemas/typescript/CompressedVideo.ts
+++ b/schemas/typescript/CompressedVideo.ts
@@ -18,7 +18,7 @@ export type CompressedVideo = {
   /**
    * Compressed video frame data.
    * 
-   * For packet-based video codecs this data must begin and end on packet boundaries (no partial packets), and must contain enough video packets to decode exactly one image (either a keyframe or delta frame). Note: Foxglove Studio does not support video streams that include B frames because they require lookahead.
+   * For packet-based video codecs this data must begin and end on packet boundaries (no partial packets), and must contain enough video packets to decode exactly one image (either a keyframe or delta frame). Note: Foxglove does not support video streams that include B frames because they require lookahead.
    */
   data: Uint8Array;
 


### PR DESCRIPTION
Update to latest links and product names.

Includes a pytest downgrade to work around a CI failure https://github.com/ros2/launch/issues/765 (similar to https://github.com/scientific-python/pytest-doctestplus/issues/240)