### PR TITLE
Remove melodic ci 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,9 +131,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - docker_image: rostooling/setup-ros-docker:ubuntu-bionic-ros-melodic-ros-base-latest
-            ros_distribution: melodic
-            ros_version: 1
           - docker_image: rostooling/setup-ros-docker:ubuntu-focal-ros-noetic-ros-base-latest
             ros_distribution: noetic
             ros_version: 1


### PR DESCRIPTION
The ros CI action to use node v20 which can no longer run on this version of ubuntu.