### PR TITLE
Add explicit field IDs to flatbuffer schemas

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Validate Flatbuffer definitions
         run: |
-          output=$(flatc --ts -o /dev/null ./schemas/flatbuffer/*.fbs)
+          output=$(flatc --require-explicit-ids --ts -o /dev/null ./schemas/flatbuffer/*.fbs)
           if [ -n "$output" ]; then
             echo "::error::Flatbuffer schema compilation had warnings or errors. Fix them to proceed:"
             echo "$output"

--- a/internal/generateFlatbufferSchema.test.ts
+++ b/internal/generateFlatbufferSchema.test.ts
@@ -24,83 +24,83 @@ describe("generateFlatbuffers", () => {
       /// An example type
       table ExampleMessage {
         /// duration field
-        field_duration:Duration;
+        field_duration:Duration (id: 0);
 
         /// time field
-        field_time:Time;
+        field_time:Time (id: 1);
 
         /// boolean field
-        field_boolean:bool = true;
+        field_boolean:bool = true (id: 2);
 
         /// bytes field
-        field_bytes:[uint8];
+        field_bytes:[uint8] (id: 3);
 
         /// float64 field
-        field_float64:double = 1.0;
+        field_float64:double = 1.0 (id: 4);
 
         /// uint32 field
-        field_uint32:uint32 = 5;
+        field_uint32:uint32 = 5 (id: 5);
 
         /// string field
-        field_string:string = "string-type";
+        field_string:string = "string-type" (id: 6);
 
         /// duration array field
-        field_duration_array:[Duration];
+        field_duration_array:[Duration] (id: 7);
 
         /// time array field
-        field_time_array:[Time];
+        field_time_array:[Time] (id: 8);
 
         /// boolean array field
-        field_boolean_array:[bool];
+        field_boolean_array:[bool] (id: 9);
 
         /// bytes array field
-        field_bytes_array:[ByteVector];
+        field_bytes_array:[ByteVector] (id: 10);
 
         /// float64 array field
-        field_float64_array:[double];
+        field_float64_array:[double] (id: 11);
 
         /// uint32 array field
-        field_uint32_array:[uint32];
+        field_uint32_array:[uint32] (id: 12);
 
         /// string array field
-        field_string_array:[string];
+        field_string_array:[string] (id: 13);
 
         /// duration fixed-length array field
         /// length 3
-        field_duration_fixed_array:[Duration];
+        field_duration_fixed_array:[Duration] (id: 14);
 
         /// time fixed-length array field
         /// length 3
-        field_time_fixed_array:[Time];
+        field_time_fixed_array:[Time] (id: 15);
 
         /// boolean fixed-length array field
         /// length 3
-        field_boolean_fixed_array:[bool];
+        field_boolean_fixed_array:[bool] (id: 16);
 
         /// bytes fixed-length array field
         /// length 3
-        field_bytes_fixed_array:[ByteVector];
+        field_bytes_fixed_array:[ByteVector] (id: 17);
 
         /// float64 fixed-length array field
         /// length 3
-        field_float64_fixed_array:[double];
+        field_float64_fixed_array:[double] (id: 18);
 
         /// uint32 fixed-length array field
         /// length 3
-        field_uint32_fixed_array:[uint32];
+        field_uint32_fixed_array:[uint32] (id: 19);
 
         /// string fixed-length array field
         /// length 3
-        field_string_fixed_array:[string];
+        field_string_fixed_array:[string] (id: 20);
 
         /// An enum field
-        field_enum:ExampleEnum;
+        field_enum:ExampleEnum (id: 21);
 
         /// An enum array field
-        field_enum_array:[ExampleEnum];
+        field_enum_array:[ExampleEnum] (id: 22);
 
         /// A nested field
-        field_nested:foxglove.NestedMessage;
+        field_nested:foxglove.NestedMessage (id: 23);
 
         /// A nested array field
         /// With
@@ -108,7 +108,7 @@ describe("generateFlatbuffers", () => {
         /// very
         /// long
         /// description
-        field_nested_array:[foxglove.NestedMessage];
+        field_nested_array:[foxglove.NestedMessage] (id: 24);
       }
 
       root_type ExampleMessage;

--- a/internal/generateFlatbufferSchema.ts
+++ b/internal/generateFlatbufferSchema.ts
@@ -6,7 +6,7 @@ namespace foxglove;
 
 /// Used for nesting byte vectors
 table ByteVector {
-  data:[uint8];
+  data:[uint8] (id: 0);
 }
 root_type ByteVector;
 `;
@@ -29,7 +29,7 @@ namespace foxglove;
 struct Duration {
   /// Signed seconds of the span of time. Must be from -315,576,000,000 to +315,576,000,000 inclusive.
   sec:int32;
-  /// if sec === 0 : -999,999,999 <= nsec <= +999,999,999 
+  /// if sec === 0 : -999,999,999 <= nsec <= +999,999,999
   /// otherwise sign of sec must match sign of nsec or be 0 and abs(nsec) <= 999,999,999
   nsec:int32;
 }
@@ -90,7 +90,7 @@ export function generateFlatbuffers(
       break;
     }
     case "message": {
-      const fields = schema.fields.map((field) => {
+      const fields = schema.fields.map((field, fieldId) => {
         const isArray = field.array != undefined;
 
         let type;
@@ -162,7 +162,7 @@ export function generateFlatbuffers(
           // convert field.name to lowercase for flatbuffer compilation compliance
         }  ${field.name.toLowerCase()}:${isArray ? `[${type}]` : type}${
           defaultValue ? ` = ${defaultValue}` : ""
-        };`;
+        } (id: ${fieldId});`;
       });
 
       definition = `${enumDefinitions.join("\n\n")}/// ${schema.description}\ntable ${

--- a/python/Makefile
+++ b/python/Makefile
@@ -12,6 +12,7 @@ endif
 generate-flatbuffer:
 	find foxglove-schemas-flatbuffer/foxglove_schemas_flatbuffer ! -name '__init__.py' -type f -exec rm -f {} +
 	pipenv run flatc \
+		--require-explicit-ids \
 		--python \
 		-o foxglove-schemas-flatbuffer/foxglove_schemas_flatbuffer \
 		../schemas/flatbuffer/*.fbs

--- a/schemas/flatbuffer/ArrowPrimitive.fbs
+++ b/schemas/flatbuffer/ArrowPrimitive.fbs
@@ -8,22 +8,22 @@ namespace foxglove;
 /// A primitive representing an arrow
 table ArrowPrimitive {
   /// Position of the arrow's tail and orientation of the arrow. Identity orientation means the arrow points in the +x direction.
-  pose:foxglove.Pose;
+  pose:foxglove.Pose (id: 0);
 
   /// Length of the arrow shaft
-  shaft_length:double;
+  shaft_length:double (id: 1);
 
   /// Diameter of the arrow shaft
-  shaft_diameter:double;
+  shaft_diameter:double (id: 2);
 
   /// Length of the arrow head
-  head_length:double;
+  head_length:double (id: 3);
 
   /// Diameter of the arrow head
-  head_diameter:double;
+  head_diameter:double (id: 4);
 
   /// Color of the arrow
-  color:foxglove.Color;
+  color:foxglove.Color (id: 5);
 }
 
 root_type ArrowPrimitive;

--- a/schemas/flatbuffer/ByteVector.fbs
+++ b/schemas/flatbuffer/ByteVector.fbs
@@ -3,6 +3,6 @@ namespace foxglove;
 
 /// Used for nesting byte vectors
 table ByteVector {
-  data:[uint8];
+  data:[uint8] (id: 0);
 }
 root_type ByteVector;

--- a/schemas/flatbuffer/CameraCalibration.fbs
+++ b/schemas/flatbuffer/CameraCalibration.fbs
@@ -7,24 +7,24 @@ namespace foxglove;
 /// Camera calibration parameters
 table CameraCalibration {
   /// Timestamp of calibration data
-  timestamp:Time;
+  timestamp:Time (id: 0);
 
   /// Frame of reference for the camera. The origin of the frame is the optical center of the camera. +x points to the right in the image, +y points down, and +z points into the plane of the image.
-  frame_id:string;
+  frame_id:string (id: 1);
 
   /// Image width
-  width:uint32;
+  width:uint32 (id: 2);
 
   /// Image height
-  height:uint32;
+  height:uint32 (id: 3);
 
   /// Name of distortion model
   /// 
   /// Supported parameters: `plumb_bob` (k1, k2, p1, p2, k3) and `rational_polynomial` (k1, k2, p1, p2, k3, k4, k5, k6). Distortion models are based on [OpenCV's](https://docs.opencv.org/2.4/modules/calib3d/doc/camera_calibration_and_3d_reconstruction.html) [pinhole camera model](https://en.wikipedia.org/wiki/Distortion_%28optics%29#Software_correction). This is the same [implementation used by ROS](http://docs.ros.org/en/diamondback/api/image_geometry/html/c++/pinhole__camera__model_8cpp_source.html)
-  distortion_model:string;
+  distortion_model:string (id: 4);
 
   /// Distortion parameters
-  d:[double];
+  d:[double] (id: 5);
 
   /// Intrinsic camera matrix (3x3 row-major matrix)
   /// 
@@ -38,13 +38,13 @@ table CameraCalibration {
   ///     [ 0  0  1]
   /// ```
   /// length 9
-  k:[double];
+  k:[double] (id: 6);
 
   /// Rectification matrix (stereo cameras only, 3x3 row-major matrix)
   /// 
   /// A rotation matrix aligning the camera coordinate system to the ideal stereo image plane so that epipolar lines in both stereo images are parallel.
   /// length 9
-  r:[double];
+  r:[double] (id: 7);
 
   /// Projection/camera matrix (3x4 row-major matrix)
   /// 
@@ -72,7 +72,7 @@ table CameraCalibration {
   /// 
   /// This holds for both images of a stereo pair.
   /// length 12
-  p:[double];
+  p:[double] (id: 8);
 }
 
 root_type CameraCalibration;

--- a/schemas/flatbuffer/CircleAnnotation.fbs
+++ b/schemas/flatbuffer/CircleAnnotation.fbs
@@ -9,22 +9,22 @@ namespace foxglove;
 /// A circle annotation on a 2D image
 table CircleAnnotation {
   /// Timestamp of circle
-  timestamp:Time;
+  timestamp:Time (id: 0);
 
   /// Center of the circle in 2D image coordinates (pixels)
-  position:foxglove.Point2;
+  position:foxglove.Point2 (id: 1);
 
   /// Circle diameter in pixels
-  diameter:double;
+  diameter:double (id: 2);
 
   /// Line thickness in pixels
-  thickness:double;
+  thickness:double (id: 3);
 
   /// Fill color
-  fill_color:foxglove.Color;
+  fill_color:foxglove.Color (id: 4);
 
   /// Outline color
-  outline_color:foxglove.Color;
+  outline_color:foxglove.Color (id: 5);
 }
 
 root_type CircleAnnotation;

--- a/schemas/flatbuffer/Color.fbs
+++ b/schemas/flatbuffer/Color.fbs
@@ -5,16 +5,16 @@ namespace foxglove;
 /// A color in RGBA format
 table Color {
   /// Red value between 0 and 1
-  r:double = 1.0;
+  r:double = 1.0 (id: 0);
 
   /// Green value between 0 and 1
-  g:double = 1.0;
+  g:double = 1.0 (id: 1);
 
   /// Blue value between 0 and 1
-  b:double = 1.0;
+  b:double = 1.0 (id: 2);
 
   /// Alpha value between 0 and 1
-  a:double = 1.0;
+  a:double = 1.0 (id: 3);
 }
 
 root_type Color;

--- a/schemas/flatbuffer/CompressedImage.fbs
+++ b/schemas/flatbuffer/CompressedImage.fbs
@@ -7,18 +7,18 @@ namespace foxglove;
 /// A compressed image
 table CompressedImage {
   /// Timestamp of image
-  timestamp:Time;
+  timestamp:Time (id: 0);
 
   /// Frame of reference for the image. The origin of the frame is the optical center of the camera. +x points to the right in the image, +y points down, and +z points into the plane of the image.
-  frame_id:string;
+  frame_id:string (id: 1);
 
   /// Compressed image data
-  data:[uint8];
+  data:[uint8] (id: 2);
 
   /// Image format
   /// 
   /// Supported values: image media types supported by Chrome, such as `webp`, `jpeg`, `png`
-  format:string;
+  format:string (id: 3);
 }
 
 root_type CompressedImage;

--- a/schemas/flatbuffer/CompressedVideo.fbs
+++ b/schemas/flatbuffer/CompressedVideo.fbs
@@ -7,22 +7,22 @@ namespace foxglove;
 /// A single frame of a compressed video bitstream
 table CompressedVideo {
   /// Timestamp of video frame
-  timestamp:Time;
+  timestamp:Time (id: 0);
 
   /// Frame of reference for the video.
   /// 
   /// The origin of the frame is the optical center of the camera. +x points to the right in the video, +y points down, and +z points into the plane of the video.
-  frame_id:string;
+  frame_id:string (id: 1);
 
   /// Compressed video frame data.
   /// 
   /// For packet-based video codecs this data must begin and end on packet boundaries (no partial packets), and must contain enough video packets to decode exactly one image (either a keyframe or delta frame). Note: Foxglove does not support video streams that include B frames because they require lookahead.
-  data:[uint8];
+  data:[uint8] (id: 2);
 
   /// Video format.
   /// 
   /// Supported values: `h264` (Annex B formatted data only)
-  format:string;
+  format:string (id: 3);
 }
 
 root_type CompressedVideo;

--- a/schemas/flatbuffer/CubePrimitive.fbs
+++ b/schemas/flatbuffer/CubePrimitive.fbs
@@ -9,13 +9,13 @@ namespace foxglove;
 /// A primitive representing a cube or rectangular prism
 table CubePrimitive {
   /// Position of the center of the cube and orientation of the cube
-  pose:foxglove.Pose;
+  pose:foxglove.Pose (id: 0);
 
   /// Size of the cube along each axis
-  size:foxglove.Vector3;
+  size:foxglove.Vector3 (id: 1);
 
   /// Color of the cube
-  color:foxglove.Color;
+  color:foxglove.Color (id: 2);
 }
 
 root_type CubePrimitive;

--- a/schemas/flatbuffer/CylinderPrimitive.fbs
+++ b/schemas/flatbuffer/CylinderPrimitive.fbs
@@ -9,19 +9,19 @@ namespace foxglove;
 /// A primitive representing a cylinder, elliptic cylinder, or truncated cone
 table CylinderPrimitive {
   /// Position of the center of the cylinder and orientation of the cylinder. The flat face(s) are perpendicular to the z-axis.
-  pose:foxglove.Pose;
+  pose:foxglove.Pose (id: 0);
 
   /// Size of the cylinder's bounding box
-  size:foxglove.Vector3;
+  size:foxglove.Vector3 (id: 1);
 
   /// 0-1, ratio of the diameter of the cylinder's bottom face (min z) to the bottom of the bounding box
-  bottom_scale:double;
+  bottom_scale:double (id: 2);
 
   /// 0-1, ratio of the diameter of the cylinder's top face (max z) to the top of the bounding box
-  top_scale:double;
+  top_scale:double (id: 3);
 
   /// Color of the cylinder
-  color:foxglove.Color;
+  color:foxglove.Color (id: 4);
 }
 
 root_type CylinderPrimitive;

--- a/schemas/flatbuffer/Duration.fbs
+++ b/schemas/flatbuffer/Duration.fbs
@@ -4,7 +4,7 @@ namespace foxglove;
 struct Duration {
   /// Signed seconds of the span of time. Must be from -315,576,000,000 to +315,576,000,000 inclusive.
   sec:int32;
-  /// if sec === 0 : -999,999,999 <= nsec <= +999,999,999 
+  /// if sec === 0 : -999,999,999 <= nsec <= +999,999,999
   /// otherwise sign of sec must match sign of nsec or be 0 and abs(nsec) <= 999,999,999
   nsec:int32;
 }

--- a/schemas/flatbuffer/FrameTransform.fbs
+++ b/schemas/flatbuffer/FrameTransform.fbs
@@ -9,19 +9,19 @@ namespace foxglove;
 /// A transform between two reference frames in 3D space
 table FrameTransform {
   /// Timestamp of transform
-  timestamp:Time;
+  timestamp:Time (id: 0);
 
   /// Name of the parent frame
-  parent_frame_id:string;
+  parent_frame_id:string (id: 1);
 
   /// Name of the child frame
-  child_frame_id:string;
+  child_frame_id:string (id: 2);
 
   /// Translation component of the transform
-  translation:foxglove.Vector3;
+  translation:foxglove.Vector3 (id: 3);
 
   /// Rotation component of the transform
-  rotation:foxglove.Quaternion;
+  rotation:foxglove.Quaternion (id: 4);
 }
 
 root_type FrameTransform;

--- a/schemas/flatbuffer/FrameTransforms.fbs
+++ b/schemas/flatbuffer/FrameTransforms.fbs
@@ -7,7 +7,7 @@ namespace foxglove;
 /// An array of FrameTransform messages
 table FrameTransforms {
   /// Array of transforms
-  transforms:[foxglove.FrameTransform];
+  transforms:[foxglove.FrameTransform] (id: 0);
 }
 
 root_type FrameTransforms;

--- a/schemas/flatbuffer/GeoJSON.fbs
+++ b/schemas/flatbuffer/GeoJSON.fbs
@@ -5,7 +5,7 @@ namespace foxglove;
 /// GeoJSON data for annotating maps
 table GeoJSON {
   /// GeoJSON data encoded as a UTF-8 string
-  geojson:string;
+  geojson:string (id: 0);
 }
 
 root_type GeoJSON;

--- a/schemas/flatbuffer/Grid.fbs
+++ b/schemas/flatbuffer/Grid.fbs
@@ -10,31 +10,31 @@ namespace foxglove;
 /// A 2D grid of data
 table Grid {
   /// Timestamp of grid
-  timestamp:Time;
+  timestamp:Time (id: 0);
 
   /// Frame of reference
-  frame_id:string;
+  frame_id:string (id: 1);
 
   /// Origin of grid's corner relative to frame of reference; grid is positioned in the x-y plane relative to this origin
-  pose:foxglove.Pose;
+  pose:foxglove.Pose (id: 2);
 
   /// Number of grid columns
-  column_count:uint32;
+  column_count:uint32 (id: 3);
 
   /// Size of single grid cell along x and y axes, relative to `pose`
-  cell_size:foxglove.Vector2;
+  cell_size:foxglove.Vector2 (id: 4);
 
   /// Number of bytes between rows in `data`
-  row_stride:uint32;
+  row_stride:uint32 (id: 5);
 
   /// Number of bytes between cells within a row in `data`
-  cell_stride:uint32;
+  cell_stride:uint32 (id: 6);
 
   /// Fields in `data`. `red`, `green`, `blue`, and `alpha` are optional for customizing the grid's color.
-  fields:[foxglove.PackedElementField];
+  fields:[foxglove.PackedElementField] (id: 7);
 
   /// Grid cell data, interpreted using `fields`, in row-major (y-major) order
-  data:[uint8];
+  data:[uint8] (id: 8);
 }
 
 root_type Grid;

--- a/schemas/flatbuffer/ImageAnnotations.fbs
+++ b/schemas/flatbuffer/ImageAnnotations.fbs
@@ -9,13 +9,13 @@ namespace foxglove;
 /// Array of annotations for a 2D image
 table ImageAnnotations {
   /// Circle annotations
-  circles:[foxglove.CircleAnnotation];
+  circles:[foxglove.CircleAnnotation] (id: 0);
 
   /// Points annotations
-  points:[foxglove.PointsAnnotation];
+  points:[foxglove.PointsAnnotation] (id: 1);
 
   /// Text annotations
-  texts:[foxglove.TextAnnotation];
+  texts:[foxglove.TextAnnotation] (id: 2);
 }
 
 root_type ImageAnnotations;

--- a/schemas/flatbuffer/KeyValuePair.fbs
+++ b/schemas/flatbuffer/KeyValuePair.fbs
@@ -5,10 +5,10 @@ namespace foxglove;
 /// A key with its associated value
 table KeyValuePair {
   /// Key
-  key:string;
+  key:string (id: 0);
 
   /// Value
-  value:string;
+  value:string (id: 1);
 }
 
 root_type KeyValuePair;

--- a/schemas/flatbuffer/LaserScan.fbs
+++ b/schemas/flatbuffer/LaserScan.fbs
@@ -8,25 +8,25 @@ namespace foxglove;
 /// A single scan from a planar laser range-finder
 table LaserScan {
   /// Timestamp of scan
-  timestamp:Time;
+  timestamp:Time (id: 0);
 
   /// Frame of reference
-  frame_id:string;
+  frame_id:string (id: 1);
 
   /// Origin of scan relative to frame of reference; points are positioned in the x-y plane relative to this origin; angles are interpreted as counterclockwise rotations around the z axis with 0 rad being in the +x direction
-  pose:foxglove.Pose;
+  pose:foxglove.Pose (id: 2);
 
   /// Bearing of first point, in radians
-  start_angle:double;
+  start_angle:double (id: 3);
 
   /// Bearing of last point, in radians
-  end_angle:double;
+  end_angle:double (id: 4);
 
   /// Distance of detections from origin; assumed to be at equally-spaced angles between `start_angle` and `end_angle`
-  ranges:[double];
+  ranges:[double] (id: 5);
 
   /// Intensity of detections
-  intensities:[double];
+  intensities:[double] (id: 6);
 }
 
 root_type LaserScan;

--- a/schemas/flatbuffer/LinePrimitive.fbs
+++ b/schemas/flatbuffer/LinePrimitive.fbs
@@ -20,30 +20,30 @@ enum LineType : ubyte {
 /// A primitive representing a series of points connected by lines
 table LinePrimitive {
   /// Drawing primitive to use for lines
-  type:LineType;
+  type:LineType (id: 0);
 
   /// Origin of lines relative to reference frame
-  pose:foxglove.Pose;
+  pose:foxglove.Pose (id: 1);
 
   /// Line thickness
-  thickness:double;
+  thickness:double (id: 2);
 
   /// Indicates whether `thickness` is a fixed size in screen pixels (true), or specified in world coordinates and scales with distance from the camera (false)
-  scale_invariant:bool;
+  scale_invariant:bool (id: 3);
 
   /// Points along the line
-  points:[foxglove.Point3];
+  points:[foxglove.Point3] (id: 4);
 
   /// Solid color to use for the whole line. One of `color` or `colors` must be provided.
-  color:foxglove.Color;
+  color:foxglove.Color (id: 5);
 
   /// Per-point colors (if specified, must have the same length as `points`). One of `color` or `colors` must be provided.
-  colors:[foxglove.Color];
+  colors:[foxglove.Color] (id: 6);
 
   /// Indices into the `points` and `colors` attribute arrays, which can be used to avoid duplicating attribute data.
   /// 
   /// If omitted or empty, indexing will not be used. This default behavior is equivalent to specifying [0, 1, ..., N-1] for the indices (where N is the number of `points` provided).
-  indices:[uint32];
+  indices:[uint32] (id: 7);
 }
 
 root_type LinePrimitive;

--- a/schemas/flatbuffer/LocationFix.fbs
+++ b/schemas/flatbuffer/LocationFix.fbs
@@ -17,26 +17,26 @@ enum PositionCovarianceType : ubyte {
 /// A navigation satellite fix for any Global Navigation Satellite System
 table LocationFix {
   /// Timestamp of the message
-  timestamp:Time;
+  timestamp:Time (id: 0);
 
   /// Frame for the sensor. Latitude and longitude readings are at the origin of the frame.
-  frame_id:string;
+  frame_id:string (id: 1);
 
   /// Latitude in degrees
-  latitude:double;
+  latitude:double (id: 2);
 
   /// Longitude in degrees
-  longitude:double;
+  longitude:double (id: 3);
 
   /// Altitude in meters
-  altitude:double;
+  altitude:double (id: 4);
 
   /// Position covariance (m^2) defined relative to a tangential plane through the reported position. The components are East, North, and Up (ENU), in row-major order.
   /// length 9
-  position_covariance:[double];
+  position_covariance:[double] (id: 5);
 
   /// If `position_covariance` is available, `position_covariance_type` must be set to indicate the type of covariance.
-  position_covariance_type:PositionCovarianceType;
+  position_covariance_type:PositionCovarianceType (id: 6);
 }
 
 root_type LocationFix;

--- a/schemas/flatbuffer/Log.fbs
+++ b/schemas/flatbuffer/Log.fbs
@@ -21,22 +21,22 @@ enum LogLevel : ubyte {
 /// A log message
 table Log {
   /// Timestamp of log message
-  timestamp:Time;
+  timestamp:Time (id: 0);
 
   /// Log level
-  level:LogLevel;
+  level:LogLevel (id: 1);
 
   /// Log message
-  message:string;
+  message:string (id: 2);
 
   /// Process or node name
-  name:string;
+  name:string (id: 3);
 
   /// Filename
-  file:string;
+  file:string (id: 4);
 
   /// Line number in the file
-  line:uint32;
+  line:uint32 (id: 5);
 }
 
 root_type Log;

--- a/schemas/flatbuffer/ModelPrimitive.fbs
+++ b/schemas/flatbuffer/ModelPrimitive.fbs
@@ -9,25 +9,25 @@ namespace foxglove;
 /// A primitive representing a 3D model file loaded from an external URL or embedded data
 table ModelPrimitive {
   /// Origin of model relative to reference frame
-  pose:foxglove.Pose;
+  pose:foxglove.Pose (id: 0);
 
   /// Scale factor to apply to the model along each axis
-  scale:foxglove.Vector3;
+  scale:foxglove.Vector3 (id: 1);
 
   /// Solid color to use for the whole model if `override_color` is true.
-  color:foxglove.Color;
+  color:foxglove.Color (id: 2);
 
   /// Whether to use the color specified in `color` instead of any materials embedded in the original model.
-  override_color:bool;
+  override_color:bool (id: 3);
 
   /// URL pointing to model file. One of `url` or `data` should be provided.
-  url:string;
+  url:string (id: 4);
 
   /// [Media type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types) of embedded model (e.g. `model/gltf-binary`). Required if `data` is provided instead of `url`. Overrides the inferred media type if `url` is provided.
-  media_type:string;
+  media_type:string (id: 5);
 
   /// Embedded model. One of `url` or `data` should be provided. If `data` is provided, `media_type` must be set to indicate the type of the data.
-  data:[uint8];
+  data:[uint8] (id: 6);
 }
 
 root_type ModelPrimitive;

--- a/schemas/flatbuffer/PackedElementField.fbs
+++ b/schemas/flatbuffer/PackedElementField.fbs
@@ -25,13 +25,13 @@ enum NumericType : ubyte {
 /// A field present within each element in a byte array of packed elements.
 table PackedElementField {
   /// Name of the field
-  name:string;
+  name:string (id: 0);
 
   /// Byte offset from start of data buffer
-  offset:uint32;
+  offset:uint32 (id: 1);
 
   /// Type of data in the field. Integers are stored using little-endian byte order.
-  type:NumericType;
+  type:NumericType (id: 2);
 }
 
 root_type PackedElementField;

--- a/schemas/flatbuffer/Point2.fbs
+++ b/schemas/flatbuffer/Point2.fbs
@@ -5,10 +5,10 @@ namespace foxglove;
 /// A point representing a position in 2D space
 table Point2 {
   /// x coordinate position
-  x:double;
+  x:double (id: 0);
 
   /// y coordinate position
-  y:double;
+  y:double (id: 1);
 }
 
 root_type Point2;

--- a/schemas/flatbuffer/Point3.fbs
+++ b/schemas/flatbuffer/Point3.fbs
@@ -5,13 +5,13 @@ namespace foxglove;
 /// A point representing a position in 3D space
 table Point3 {
   /// x coordinate position
-  x:double;
+  x:double (id: 0);
 
   /// y coordinate position
-  y:double;
+  y:double (id: 1);
 
   /// z coordinate position
-  z:double;
+  z:double (id: 2);
 }
 
 root_type Point3;

--- a/schemas/flatbuffer/PointCloud.fbs
+++ b/schemas/flatbuffer/PointCloud.fbs
@@ -9,22 +9,22 @@ namespace foxglove;
 /// A collection of N-dimensional points, which may contain additional fields with information like normals, intensity, etc.
 table PointCloud {
   /// Timestamp of point cloud
-  timestamp:Time;
+  timestamp:Time (id: 0);
 
   /// Frame of reference
-  frame_id:string;
+  frame_id:string (id: 1);
 
   /// The origin of the point cloud relative to the frame of reference
-  pose:foxglove.Pose;
+  pose:foxglove.Pose (id: 2);
 
   /// Number of bytes between points in the `data`
-  point_stride:uint32;
+  point_stride:uint32 (id: 3);
 
   /// Fields in `data`. At least 2 coordinate fields from `x`, `y`, and `z` are required for each point's position; `red`, `green`, `blue`, and `alpha` are optional for customizing each point's color.
-  fields:[foxglove.PackedElementField];
+  fields:[foxglove.PackedElementField] (id: 4);
 
   /// Point data, interpreted using `fields`
-  data:[uint8];
+  data:[uint8] (id: 5);
 }
 
 root_type PointCloud;

--- a/schemas/flatbuffer/PointsAnnotation.fbs
+++ b/schemas/flatbuffer/PointsAnnotation.fbs
@@ -25,25 +25,25 @@ enum PointsAnnotationType : ubyte {
 /// An array of points on a 2D image
 table PointsAnnotation {
   /// Timestamp of annotation
-  timestamp:Time;
+  timestamp:Time (id: 0);
 
   /// Type of points annotation to draw
-  type:PointsAnnotationType;
+  type:PointsAnnotationType (id: 1);
 
   /// Points in 2D image coordinates (pixels)
-  points:[foxglove.Point2];
+  points:[foxglove.Point2] (id: 2);
 
   /// Outline color
-  outline_color:foxglove.Color;
+  outline_color:foxglove.Color (id: 3);
 
   /// Per-point colors, if `type` is `POINTS`, or per-segment stroke colors, if `type` is `LINE_LIST`, `LINE_STRIP` or `LINE_LOOP`.
-  outline_colors:[foxglove.Color];
+  outline_colors:[foxglove.Color] (id: 4);
 
   /// Fill color
-  fill_color:foxglove.Color;
+  fill_color:foxglove.Color (id: 5);
 
   /// Stroke thickness in pixels
-  thickness:double;
+  thickness:double (id: 6);
 }
 
 root_type PointsAnnotation;

--- a/schemas/flatbuffer/Pose.fbs
+++ b/schemas/flatbuffer/Pose.fbs
@@ -8,10 +8,10 @@ namespace foxglove;
 /// A position and orientation for an object or reference frame in 3D space
 table Pose {
   /// Point denoting position in 3D space
-  position:foxglove.Vector3;
+  position:foxglove.Vector3 (id: 0);
 
   /// Quaternion denoting orientation in 3D space
-  orientation:foxglove.Quaternion;
+  orientation:foxglove.Quaternion (id: 1);
 }
 
 root_type Pose;

--- a/schemas/flatbuffer/PoseInFrame.fbs
+++ b/schemas/flatbuffer/PoseInFrame.fbs
@@ -8,13 +8,13 @@ namespace foxglove;
 /// A timestamped pose for an object or reference frame in 3D space
 table PoseInFrame {
   /// Timestamp of pose
-  timestamp:Time;
+  timestamp:Time (id: 0);
 
   /// Frame of reference for pose position and orientation
-  frame_id:string;
+  frame_id:string (id: 1);
 
   /// Pose in 3D space
-  pose:foxglove.Pose;
+  pose:foxglove.Pose (id: 2);
 }
 
 root_type PoseInFrame;

--- a/schemas/flatbuffer/PosesInFrame.fbs
+++ b/schemas/flatbuffer/PosesInFrame.fbs
@@ -8,13 +8,13 @@ namespace foxglove;
 /// An array of timestamped poses for an object or reference frame in 3D space
 table PosesInFrame {
   /// Timestamp of pose
-  timestamp:Time;
+  timestamp:Time (id: 0);
 
   /// Frame of reference for pose position and orientation
-  frame_id:string;
+  frame_id:string (id: 1);
 
   /// Poses in 3D space
-  poses:[foxglove.Pose];
+  poses:[foxglove.Pose] (id: 2);
 }
 
 root_type PosesInFrame;

--- a/schemas/flatbuffer/Quaternion.fbs
+++ b/schemas/flatbuffer/Quaternion.fbs
@@ -5,16 +5,16 @@ namespace foxglove;
 /// A [quaternion](https://eater.net/quaternions) representing a rotation in 3D space
 table Quaternion {
   /// x value
-  x:double;
+  x:double (id: 0);
 
   /// y value
-  y:double;
+  y:double (id: 1);
 
   /// z value
-  z:double;
+  z:double (id: 2);
 
   /// w value
-  w:double = 1.0;
+  w:double = 1.0 (id: 3);
 }
 
 root_type Quaternion;

--- a/schemas/flatbuffer/RawImage.fbs
+++ b/schemas/flatbuffer/RawImage.fbs
@@ -7,27 +7,27 @@ namespace foxglove;
 /// A raw image
 table RawImage {
   /// Timestamp of image
-  timestamp:Time;
+  timestamp:Time (id: 0);
 
   /// Frame of reference for the image. The origin of the frame is the optical center of the camera. +x points to the right in the image, +y points down, and +z points into the plane of the image.
-  frame_id:string;
+  frame_id:string (id: 1);
 
   /// Image width
-  width:uint32;
+  width:uint32 (id: 2);
 
   /// Image height
-  height:uint32;
+  height:uint32 (id: 3);
 
   /// Encoding of the raw image data
   /// 
   /// Supported values: `8UC1`, `8UC3`, `16UC1`, `32FC1`, `bayer_bggr8`, `bayer_gbrg8`, `bayer_grbg8`, `bayer_rggb8`, `bgr8`, `bgra8`, `mono8`, `mono16`, `rgb8`, `rgba8`, `uyvy` or `yuv422`, `yuyv` or `yuv422_yuy2`
-  encoding:string;
+  encoding:string (id: 4);
 
   /// Byte length of a single row
-  step:uint32;
+  step:uint32 (id: 5);
 
   /// Raw image data
-  data:[uint8];
+  data:[uint8] (id: 6);
 }
 
 root_type RawImage;

--- a/schemas/flatbuffer/SceneEntity.fbs
+++ b/schemas/flatbuffer/SceneEntity.fbs
@@ -17,46 +17,46 @@ namespace foxglove;
 /// A visual element in a 3D scene. An entity may be composed of multiple primitives which all share the same frame of reference.
 table SceneEntity {
   /// Timestamp of the entity
-  timestamp:Time;
+  timestamp:Time (id: 0);
 
   /// Frame of reference
-  frame_id:string;
+  frame_id:string (id: 1);
 
   /// Identifier for the entity. A entity will replace any prior entity on the same topic with the same `id`.
-  id:string;
+  id:string (id: 2);
 
   /// Length of time (relative to `timestamp`) after which the entity should be automatically removed. Zero value indicates the entity should remain visible until it is replaced or deleted.
-  lifetime:Duration;
+  lifetime:Duration (id: 3);
 
   /// Whether the entity should keep its location in the fixed frame (false) or follow the frame specified in `frame_id` as it moves relative to the fixed frame (true)
-  frame_locked:bool;
+  frame_locked:bool (id: 4);
 
   /// Additional user-provided metadata associated with the entity. Keys must be unique.
-  metadata:[foxglove.KeyValuePair];
+  metadata:[foxglove.KeyValuePair] (id: 5);
 
   /// Arrow primitives
-  arrows:[foxglove.ArrowPrimitive];
+  arrows:[foxglove.ArrowPrimitive] (id: 6);
 
   /// Cube primitives
-  cubes:[foxglove.CubePrimitive];
+  cubes:[foxglove.CubePrimitive] (id: 7);
 
   /// Sphere primitives
-  spheres:[foxglove.SpherePrimitive];
+  spheres:[foxglove.SpherePrimitive] (id: 8);
 
   /// Cylinder primitives
-  cylinders:[foxglove.CylinderPrimitive];
+  cylinders:[foxglove.CylinderPrimitive] (id: 9);
 
   /// Line primitives
-  lines:[foxglove.LinePrimitive];
+  lines:[foxglove.LinePrimitive] (id: 10);
 
   /// Triangle list primitives
-  triangles:[foxglove.TriangleListPrimitive];
+  triangles:[foxglove.TriangleListPrimitive] (id: 11);
 
   /// Text primitives
-  texts:[foxglove.TextPrimitive];
+  texts:[foxglove.TextPrimitive] (id: 12);
 
   /// Model primitives
-  models:[foxglove.ModelPrimitive];
+  models:[foxglove.ModelPrimitive] (id: 13);
 }
 
 root_type SceneEntity;

--- a/schemas/flatbuffer/SceneEntityDeletion.fbs
+++ b/schemas/flatbuffer/SceneEntityDeletion.fbs
@@ -15,13 +15,13 @@ enum SceneEntityDeletionType : ubyte {
 /// Command to remove previously published entities
 table SceneEntityDeletion {
   /// Timestamp of the deletion. Only matching entities earlier than this timestamp will be deleted.
-  timestamp:Time;
+  timestamp:Time (id: 0);
 
   /// Type of deletion action to perform
-  type:SceneEntityDeletionType;
+  type:SceneEntityDeletionType (id: 1);
 
   /// Identifier which must match if `type` is `MATCHING_ID`.
-  id:string;
+  id:string (id: 2);
 }
 
 root_type SceneEntityDeletion;

--- a/schemas/flatbuffer/SceneUpdate.fbs
+++ b/schemas/flatbuffer/SceneUpdate.fbs
@@ -8,10 +8,10 @@ namespace foxglove;
 /// An update to the entities displayed in a 3D scene
 table SceneUpdate {
   /// Scene entities to delete
-  deletions:[foxglove.SceneEntityDeletion];
+  deletions:[foxglove.SceneEntityDeletion] (id: 0);
 
   /// Scene entities to add or replace
-  entities:[foxglove.SceneEntity];
+  entities:[foxglove.SceneEntity] (id: 1);
 }
 
 root_type SceneUpdate;

--- a/schemas/flatbuffer/SpherePrimitive.fbs
+++ b/schemas/flatbuffer/SpherePrimitive.fbs
@@ -9,13 +9,13 @@ namespace foxglove;
 /// A primitive representing a sphere or ellipsoid
 table SpherePrimitive {
   /// Position of the center of the sphere and orientation of the sphere
-  pose:foxglove.Pose;
+  pose:foxglove.Pose (id: 0);
 
   /// Size (diameter) of the sphere along each axis
-  size:foxglove.Vector3;
+  size:foxglove.Vector3 (id: 1);
 
   /// Color of the sphere
-  color:foxglove.Color;
+  color:foxglove.Color (id: 2);
 }
 
 root_type SpherePrimitive;

--- a/schemas/flatbuffer/TextAnnotation.fbs
+++ b/schemas/flatbuffer/TextAnnotation.fbs
@@ -9,22 +9,22 @@ namespace foxglove;
 /// A text label on a 2D image
 table TextAnnotation {
   /// Timestamp of annotation
-  timestamp:Time;
+  timestamp:Time (id: 0);
 
   /// Bottom-left origin of the text label in 2D image coordinates (pixels)
-  position:foxglove.Point2;
+  position:foxglove.Point2 (id: 1);
 
   /// Text to display
-  text:string;
+  text:string (id: 2);
 
   /// Font size in pixels
-  font_size:double = 12.0;
+  font_size:double = 12.0 (id: 3);
 
   /// Text color
-  text_color:foxglove.Color;
+  text_color:foxglove.Color (id: 4);
 
   /// Background fill color
-  background_color:foxglove.Color;
+  background_color:foxglove.Color (id: 5);
 }
 
 root_type TextAnnotation;

--- a/schemas/flatbuffer/TextPrimitive.fbs
+++ b/schemas/flatbuffer/TextPrimitive.fbs
@@ -8,22 +8,22 @@ namespace foxglove;
 /// A primitive representing a text label
 table TextPrimitive {
   /// Position of the center of the text box and orientation of the text. Identity orientation means the text is oriented in the xy-plane and flows from -x to +x.
-  pose:foxglove.Pose;
+  pose:foxglove.Pose (id: 0);
 
   /// Whether the text should respect `pose.orientation` (false) or always face the camera (true)
-  billboard:bool;
+  billboard:bool (id: 1);
 
   /// Font size (height of one line of text)
-  font_size:double;
+  font_size:double (id: 2);
 
   /// Indicates whether `font_size` is a fixed size in screen pixels (true), or specified in world coordinates and scales with distance from the camera (false)
-  scale_invariant:bool;
+  scale_invariant:bool (id: 3);
 
   /// Color of the text
-  color:foxglove.Color;
+  color:foxglove.Color (id: 4);
 
   /// Text
-  text:string;
+  text:string (id: 5);
 }
 
 root_type TextPrimitive;

--- a/schemas/flatbuffer/TriangleListPrimitive.fbs
+++ b/schemas/flatbuffer/TriangleListPrimitive.fbs
@@ -9,21 +9,21 @@ namespace foxglove;
 /// A primitive representing a set of triangles or a surface tiled by triangles
 table TriangleListPrimitive {
   /// Origin of triangles relative to reference frame
-  pose:foxglove.Pose;
+  pose:foxglove.Pose (id: 0);
 
   /// Vertices to use for triangles, interpreted as a list of triples (0-1-2, 3-4-5, ...)
-  points:[foxglove.Point3];
+  points:[foxglove.Point3] (id: 1);
 
   /// Solid color to use for the whole shape. One of `color` or `colors` must be provided.
-  color:foxglove.Color;
+  color:foxglove.Color (id: 2);
 
   /// Per-vertex colors (if specified, must have the same length as `points`). One of `color` or `colors` must be provided.
-  colors:[foxglove.Color];
+  colors:[foxglove.Color] (id: 3);
 
   /// Indices into the `points` and `colors` attribute arrays, which can be used to avoid duplicating attribute data.
   /// 
   /// If omitted or empty, indexing will not be used. This default behavior is equivalent to specifying [0, 1, ..., N-1] for the indices (where N is the number of `points` provided).
-  indices:[uint32];
+  indices:[uint32] (id: 4);
 }
 
 root_type TriangleListPrimitive;

--- a/schemas/flatbuffer/Vector2.fbs
+++ b/schemas/flatbuffer/Vector2.fbs
@@ -5,10 +5,10 @@ namespace foxglove;
 /// A vector in 2D space that represents a direction only
 table Vector2 {
   /// x coordinate length
-  x:double = 1.0;
+  x:double = 1.0 (id: 0);
 
   /// y coordinate length
-  y:double = 1.0;
+  y:double = 1.0 (id: 1);
 }
 
 root_type Vector2;

--- a/schemas/flatbuffer/Vector3.fbs
+++ b/schemas/flatbuffer/Vector3.fbs
@@ -5,13 +5,13 @@ namespace foxglove;
 /// A vector in 3D space that represents a direction only
 table Vector3 {
   /// x coordinate length
-  x:double = 1.0;
+  x:double = 1.0 (id: 0);
 
   /// y coordinate length
-  y:double = 1.0;
+  y:double = 1.0 (id: 1);
 
   /// z coordinate length
-  z:double = 1.0;
+  z:double = 1.0 (id: 2);
 }
 
 root_type Vector3;


### PR DESCRIPTION
### Changelog
Added explicit field IDs to flatbuffer schemas.

### Docs

None

### Description

This allows the schemas to be compiled with `--require-explicit-ids` turned on in `flatc`, which can be nice to help prevent people from accidentally making breaking changes to flatbuffer schemas if they choose to reorder fields (or insert new fields in the middle of the schemas). Because of how flatc works with includes, if downstream users want to use `--require-explicit-ids` on their own schemas that happen to include foxglove schema types, they must update the foxglove schemas that they use to include IDs.



