### PR TITLE
Update ImageAnnotation schemas' coordinate fields with comment specifying the coordinate space

### DIFF
--- a/internal/__snapshots__/exportTypeScriptSchemas.test.ts.snap
+++ b/internal/__snapshots__/exportTypeScriptSchemas.test.ts.snap
@@ -122,7 +122,10 @@ export type CircleAnnotation = {
   /** Timestamp of circle */
   timestamp: Time;
 
-  /** Center of the circle in 2D image coordinates (pixels) */
+  /**
+   * Center of the circle in 2D image coordinates (pixels).
+   * The coordinate uses the top-left corner of the top-left pixel of the image as the origin.
+   */
   position: Point2;
 
   /** Circle diameter in pixels */
@@ -708,7 +711,10 @@ export type PointsAnnotation = {
   /** Type of points annotation to draw */
   type: PointsAnnotationType;
 
-  /** Points in 2D image coordinates (pixels) */
+  /**
+   * Points in 2D image coordinates (pixels).
+   * These coordinates use the top-left corner of the top-left pixel of the image as the origin.
+   */
   points: Point2[];
 
   /** Outline color */
@@ -857,7 +863,10 @@ export type TextAnnotation = {
   /** Timestamp of annotation */
   timestamp: Time;
 
-  /** Bottom-left origin of the text label in 2D image coordinates (pixels) */
+  /**
+   * Bottom-left origin of the text label in 2D image coordinates (pixels).
+   * The coordinate uses the top-left corner of the top-left pixel of the image as the origin.
+   */
   position: Point2;
 
   /** Text to display */

--- a/internal/schemas.ts
+++ b/internal/schemas.ts
@@ -1085,7 +1085,8 @@ const CircleAnnotation: FoxgloveMessageSchema = {
     {
       name: "position",
       type: { type: "nested", schema: Point2 },
-      description: "Center of the circle in 2D image coordinates (pixels)",
+      description:
+        "Center of the circle in 2D image coordinates (pixels).\nThe coordinate uses the top-left corner of the top-left pixel of the image as the origin.",
     },
     {
       name: "diameter",
@@ -1147,7 +1148,8 @@ const PointsAnnotation: FoxgloveMessageSchema = {
     {
       name: "points",
       type: { type: "nested", schema: Point2 },
-      description: "Points in 2D image coordinates (pixels)",
+      description:
+        "Points in 2D image coordinates (pixels).\nThese coordinates use the top-left corner of the top-left pixel of the image as the origin.",
       array: true,
     },
     {
@@ -1188,7 +1190,8 @@ const TextAnnotation: FoxgloveMessageSchema = {
     {
       name: "position",
       type: { type: "nested", schema: Point2 },
-      description: "Bottom-left origin of the text label in 2D image coordinates (pixels)",
+      description:
+        "Bottom-left origin of the text label in 2D image coordinates (pixels).\nThe coordinate uses the top-left corner of the top-left pixel of the image as the origin.",
     },
     {
       name: "text",

--- a/ros_foxglove_msgs/ros1/CircleAnnotation.msg
+++ b/ros_foxglove_msgs/ros1/CircleAnnotation.msg
@@ -6,7 +6,8 @@
 # Timestamp of circle
 time timestamp
 
-# Center of the circle in 2D image coordinates (pixels)
+# Center of the circle in 2D image coordinates (pixels).
+# The coordinate uses the top-left corner of the top-left pixel of the image as the origin.
 foxglove_msgs/Point2 position
 
 # Circle diameter in pixels

--- a/ros_foxglove_msgs/ros1/PointsAnnotation.msg
+++ b/ros_foxglove_msgs/ros1/PointsAnnotation.msg
@@ -23,7 +23,8 @@ uint8 LINE_LIST=4
 # Type of points annotation to draw
 uint8 type
 
-# Points in 2D image coordinates (pixels)
+# Points in 2D image coordinates (pixels).
+# These coordinates use the top-left corner of the top-left pixel of the image as the origin.
 foxglove_msgs/Point2[] points
 
 # Outline color

--- a/ros_foxglove_msgs/ros1/TextAnnotation.msg
+++ b/ros_foxglove_msgs/ros1/TextAnnotation.msg
@@ -6,7 +6,8 @@
 # Timestamp of annotation
 time timestamp
 
-# Bottom-left origin of the text label in 2D image coordinates (pixels)
+# Bottom-left origin of the text label in 2D image coordinates (pixels).
+# The coordinate uses the top-left corner of the top-left pixel of the image as the origin.
 foxglove_msgs/Point2 position
 
 # Text to display

--- a/ros_foxglove_msgs/ros2/CircleAnnotation.msg
+++ b/ros_foxglove_msgs/ros2/CircleAnnotation.msg
@@ -6,7 +6,8 @@
 # Timestamp of circle
 builtin_interfaces/Time timestamp
 
-# Center of the circle in 2D image coordinates (pixels)
+# Center of the circle in 2D image coordinates (pixels).
+# The coordinate uses the top-left corner of the top-left pixel of the image as the origin.
 foxglove_msgs/Point2 position
 
 # Circle diameter in pixels

--- a/ros_foxglove_msgs/ros2/PointsAnnotation.msg
+++ b/ros_foxglove_msgs/ros2/PointsAnnotation.msg
@@ -23,7 +23,8 @@ uint8 LINE_LIST=4
 # Type of points annotation to draw
 uint8 type
 
-# Points in 2D image coordinates (pixels)
+# Points in 2D image coordinates (pixels).
+# These coordinates use the top-left corner of the top-left pixel of the image as the origin.
 foxglove_msgs/Point2[] points
 
 # Outline color

--- a/ros_foxglove_msgs/ros2/TextAnnotation.msg
+++ b/ros_foxglove_msgs/ros2/TextAnnotation.msg
@@ -6,7 +6,8 @@
 # Timestamp of annotation
 builtin_interfaces/Time timestamp
 
-# Bottom-left origin of the text label in 2D image coordinates (pixels)
+# Bottom-left origin of the text label in 2D image coordinates (pixels).
+# The coordinate uses the top-left corner of the top-left pixel of the image as the origin.
 foxglove_msgs/Point2 position
 
 # Text to display

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -427,7 +427,8 @@ Timestamp of circle
 </td>
 <td>
 
-Center of the circle in 2D image coordinates (pixels)
+Center of the circle in 2D image coordinates (pixels).
+The coordinate uses the top-left corner of the top-left pixel of the image as the origin.
 
 </td>
 </tr>
@@ -1950,7 +1951,8 @@ Type of points annotation to draw
 </td>
 <td>
 
-Points in 2D image coordinates (pixels)
+Points in 2D image coordinates (pixels).
+These coordinates use the top-left corner of the top-left pixel of the image as the origin.
 
 </td>
 </tr>
@@ -2683,7 +2685,8 @@ Timestamp of annotation
 </td>
 <td>
 
-Bottom-left origin of the text label in 2D image coordinates (pixels)
+Bottom-left origin of the text label in 2D image coordinates (pixels).
+The coordinate uses the top-left corner of the top-left pixel of the image as the origin.
 
 </td>
 </tr>

--- a/schemas/flatbuffer/CircleAnnotation.fbs
+++ b/schemas/flatbuffer/CircleAnnotation.fbs
@@ -11,7 +11,8 @@ table CircleAnnotation {
   /// Timestamp of circle
   timestamp:Time (id: 0);
 
-  /// Center of the circle in 2D image coordinates (pixels)
+  /// Center of the circle in 2D image coordinates (pixels).
+  /// The coordinate uses the top-left corner of the top-left pixel of the image as the origin.
   position:foxglove.Point2 (id: 1);
 
   /// Circle diameter in pixels

--- a/schemas/flatbuffer/PointsAnnotation.fbs
+++ b/schemas/flatbuffer/PointsAnnotation.fbs
@@ -30,7 +30,8 @@ table PointsAnnotation {
   /// Type of points annotation to draw
   type:PointsAnnotationType (id: 1);
 
-  /// Points in 2D image coordinates (pixels)
+  /// Points in 2D image coordinates (pixels).
+  /// These coordinates use the top-left corner of the top-left pixel of the image as the origin.
   points:[foxglove.Point2] (id: 2);
 
   /// Outline color

--- a/schemas/flatbuffer/TextAnnotation.fbs
+++ b/schemas/flatbuffer/TextAnnotation.fbs
@@ -11,7 +11,8 @@ table TextAnnotation {
   /// Timestamp of annotation
   timestamp:Time (id: 0);
 
-  /// Bottom-left origin of the text label in 2D image coordinates (pixels)
+  /// Bottom-left origin of the text label in 2D image coordinates (pixels).
+  /// The coordinate uses the top-left corner of the top-left pixel of the image as the origin.
   position:foxglove.Point2 (id: 1);
 
   /// Text to display

--- a/schemas/jsonschema/CircleAnnotation.json
+++ b/schemas/jsonschema/CircleAnnotation.json
@@ -22,7 +22,7 @@
     },
     "position": {
       "title": "foxglove.Point2",
-      "description": "Center of the circle in 2D image coordinates (pixels)",
+      "description": "Center of the circle in 2D image coordinates (pixels).\nThe coordinate uses the top-left corner of the top-left pixel of the image as the origin.",
       "type": "object",
       "properties": {
         "x": {

--- a/schemas/jsonschema/ImageAnnotations.json
+++ b/schemas/jsonschema/ImageAnnotations.json
@@ -29,7 +29,7 @@
           },
           "position": {
             "title": "foxglove.Point2",
-            "description": "Center of the circle in 2D image coordinates (pixels)",
+            "description": "Center of the circle in 2D image coordinates (pixels).\nThe coordinate uses the top-left corner of the top-left pixel of the image as the origin.",
             "type": "object",
             "properties": {
               "x": {
@@ -170,7 +170,7 @@
                 }
               }
             },
-            "description": "Points in 2D image coordinates (pixels)"
+            "description": "Points in 2D image coordinates (pixels).\nThese coordinates use the top-left corner of the top-left pixel of the image as the origin."
           },
           "outline_color": {
             "title": "foxglove.Color",
@@ -278,7 +278,7 @@
           },
           "position": {
             "title": "foxglove.Point2",
-            "description": "Bottom-left origin of the text label in 2D image coordinates (pixels)",
+            "description": "Bottom-left origin of the text label in 2D image coordinates (pixels).\nThe coordinate uses the top-left corner of the top-left pixel of the image as the origin.",
             "type": "object",
             "properties": {
               "x": {

--- a/schemas/jsonschema/PointsAnnotation.json
+++ b/schemas/jsonschema/PointsAnnotation.json
@@ -67,7 +67,7 @@
           }
         }
       },
-      "description": "Points in 2D image coordinates (pixels)"
+      "description": "Points in 2D image coordinates (pixels).\nThese coordinates use the top-left corner of the top-left pixel of the image as the origin."
     },
     "outline_color": {
       "title": "foxglove.Color",

--- a/schemas/jsonschema/TextAnnotation.json
+++ b/schemas/jsonschema/TextAnnotation.json
@@ -22,7 +22,7 @@
     },
     "position": {
       "title": "foxglove.Point2",
-      "description": "Bottom-left origin of the text label in 2D image coordinates (pixels)",
+      "description": "Bottom-left origin of the text label in 2D image coordinates (pixels).\nThe coordinate uses the top-left corner of the top-left pixel of the image as the origin.",
       "type": "object",
       "properties": {
         "x": {

--- a/schemas/jsonschema/index.ts
+++ b/schemas/jsonschema/index.ts
@@ -198,7 +198,7 @@ export const CircleAnnotation = {
     },
     "position": {
       "title": "foxglove.Point2",
-      "description": "Center of the circle in 2D image coordinates (pixels)",
+      "description": "Center of the circle in 2D image coordinates (pixels).\nThe coordinate uses the top-left corner of the top-left pixel of the image as the origin.",
       "type": "object",
       "properties": {
         "x": {
@@ -957,7 +957,7 @@ export const ImageAnnotations = {
           },
           "position": {
             "title": "foxglove.Point2",
-            "description": "Center of the circle in 2D image coordinates (pixels)",
+            "description": "Center of the circle in 2D image coordinates (pixels).\nThe coordinate uses the top-left corner of the top-left pixel of the image as the origin.",
             "type": "object",
             "properties": {
               "x": {
@@ -1098,7 +1098,7 @@ export const ImageAnnotations = {
                 }
               }
             },
-            "description": "Points in 2D image coordinates (pixels)"
+            "description": "Points in 2D image coordinates (pixels).\nThese coordinates use the top-left corner of the top-left pixel of the image as the origin."
           },
           "outline_color": {
             "title": "foxglove.Color",
@@ -1206,7 +1206,7 @@ export const ImageAnnotations = {
           },
           "position": {
             "title": "foxglove.Point2",
-            "description": "Bottom-left origin of the text label in 2D image coordinates (pixels)",
+            "description": "Bottom-left origin of the text label in 2D image coordinates (pixels).\nThe coordinate uses the top-left corner of the top-left pixel of the image as the origin.",
             "type": "object",
             "properties": {
               "x": {
@@ -4272,7 +4272,7 @@ export const PointsAnnotation = {
           }
         }
       },
-      "description": "Points in 2D image coordinates (pixels)"
+      "description": "Points in 2D image coordinates (pixels).\nThese coordinates use the top-left corner of the top-left pixel of the image as the origin."
     },
     "outline_color": {
       "title": "foxglove.Color",
@@ -4767,7 +4767,7 @@ export const TextAnnotation = {
     },
     "position": {
       "title": "foxglove.Point2",
-      "description": "Bottom-left origin of the text label in 2D image coordinates (pixels)",
+      "description": "Bottom-left origin of the text label in 2D image coordinates (pixels).\nThe coordinate uses the top-left corner of the top-left pixel of the image as the origin.",
       "type": "object",
       "properties": {
         "x": {

--- a/schemas/omgidl/foxglove/CircleAnnotation.idl
+++ b/schemas/omgidl/foxglove/CircleAnnotation.idl
@@ -11,7 +11,8 @@ struct CircleAnnotation {
   // Timestamp of circle
   Time timestamp;
 
-  // Center of the circle in 2D image coordinates (pixels)
+  // Center of the circle in 2D image coordinates (pixels).
+  // The coordinate uses the top-left corner of the top-left pixel of the image as the origin.
   Point2 position;
 
   // Circle diameter in pixels

--- a/schemas/omgidl/foxglove/PointsAnnotation.idl
+++ b/schemas/omgidl/foxglove/PointsAnnotation.idl
@@ -15,7 +15,8 @@ struct PointsAnnotation {
   // Type of points annotation to draw
   PointsAnnotationType type;
 
-  // Points in 2D image coordinates (pixels)
+  // Points in 2D image coordinates (pixels).
+  // These coordinates use the top-left corner of the top-left pixel of the image as the origin.
   sequence<Point2> points;
 
   // Outline color

--- a/schemas/omgidl/foxglove/TextAnnotation.idl
+++ b/schemas/omgidl/foxglove/TextAnnotation.idl
@@ -11,7 +11,8 @@ struct TextAnnotation {
   // Timestamp of annotation
   Time timestamp;
 
-  // Bottom-left origin of the text label in 2D image coordinates (pixels)
+  // Bottom-left origin of the text label in 2D image coordinates (pixels).
+  // The coordinate uses the top-left corner of the top-left pixel of the image as the origin.
   Point2 position;
 
   // Text to display

--- a/schemas/proto/foxglove/CircleAnnotation.proto
+++ b/schemas/proto/foxglove/CircleAnnotation.proto
@@ -13,7 +13,8 @@ message CircleAnnotation {
   // Timestamp of circle
   google.protobuf.Timestamp timestamp = 1;
 
-  // Center of the circle in 2D image coordinates (pixels)
+  // Center of the circle in 2D image coordinates (pixels).
+  // The coordinate uses the top-left corner of the top-left pixel of the image as the origin.
   foxglove.Point2 position = 2;
 
   // Circle diameter in pixels

--- a/schemas/proto/foxglove/PointsAnnotation.proto
+++ b/schemas/proto/foxglove/PointsAnnotation.proto
@@ -32,7 +32,8 @@ message PointsAnnotation {
   // Type of points annotation to draw
   Type type = 2;
 
-  // Points in 2D image coordinates (pixels)
+  // Points in 2D image coordinates (pixels).
+  // These coordinates use the top-left corner of the top-left pixel of the image as the origin.
   repeated foxglove.Point2 points = 3;
 
   // Outline color

--- a/schemas/proto/foxglove/TextAnnotation.proto
+++ b/schemas/proto/foxglove/TextAnnotation.proto
@@ -13,7 +13,8 @@ message TextAnnotation {
   // Timestamp of annotation
   google.protobuf.Timestamp timestamp = 1;
 
-  // Bottom-left origin of the text label in 2D image coordinates (pixels)
+  // Bottom-left origin of the text label in 2D image coordinates (pixels).
+  // The coordinate uses the top-left corner of the top-left pixel of the image as the origin.
   foxglove.Point2 position = 2;
 
   // Text to display

--- a/schemas/ros1/CircleAnnotation.msg
+++ b/schemas/ros1/CircleAnnotation.msg
@@ -6,7 +6,8 @@
 # Timestamp of circle
 time timestamp
 
-# Center of the circle in 2D image coordinates (pixels)
+# Center of the circle in 2D image coordinates (pixels).
+# The coordinate uses the top-left corner of the top-left pixel of the image as the origin.
 foxglove_msgs/Point2 position
 
 # Circle diameter in pixels

--- a/schemas/ros1/PointsAnnotation.msg
+++ b/schemas/ros1/PointsAnnotation.msg
@@ -23,7 +23,8 @@ uint8 LINE_LIST=4
 # Type of points annotation to draw
 uint8 type
 
-# Points in 2D image coordinates (pixels)
+# Points in 2D image coordinates (pixels).
+# These coordinates use the top-left corner of the top-left pixel of the image as the origin.
 foxglove_msgs/Point2[] points
 
 # Outline color

--- a/schemas/ros1/TextAnnotation.msg
+++ b/schemas/ros1/TextAnnotation.msg
@@ -6,7 +6,8 @@
 # Timestamp of annotation
 time timestamp
 
-# Bottom-left origin of the text label in 2D image coordinates (pixels)
+# Bottom-left origin of the text label in 2D image coordinates (pixels).
+# The coordinate uses the top-left corner of the top-left pixel of the image as the origin.
 foxglove_msgs/Point2 position
 
 # Text to display

--- a/schemas/ros2/CircleAnnotation.msg
+++ b/schemas/ros2/CircleAnnotation.msg
@@ -6,7 +6,8 @@
 # Timestamp of circle
 builtin_interfaces/Time timestamp
 
-# Center of the circle in 2D image coordinates (pixels)
+# Center of the circle in 2D image coordinates (pixels).
+# The coordinate uses the top-left corner of the top-left pixel of the image as the origin.
 foxglove_msgs/Point2 position
 
 # Circle diameter in pixels

--- a/schemas/ros2/PointsAnnotation.msg
+++ b/schemas/ros2/PointsAnnotation.msg
@@ -23,7 +23,8 @@ uint8 LINE_LIST=4
 # Type of points annotation to draw
 uint8 type
 
-# Points in 2D image coordinates (pixels)
+# Points in 2D image coordinates (pixels).
+# These coordinates use the top-left corner of the top-left pixel of the image as the origin.
 foxglove_msgs/Point2[] points
 
 # Outline color

--- a/schemas/ros2/TextAnnotation.msg
+++ b/schemas/ros2/TextAnnotation.msg
@@ -6,7 +6,8 @@
 # Timestamp of annotation
 builtin_interfaces/Time timestamp
 
-# Bottom-left origin of the text label in 2D image coordinates (pixels)
+# Bottom-left origin of the text label in 2D image coordinates (pixels).
+# The coordinate uses the top-left corner of the top-left pixel of the image as the origin.
 foxglove_msgs/Point2 position
 
 # Text to display

--- a/schemas/typescript/CircleAnnotation.ts
+++ b/schemas/typescript/CircleAnnotation.ts
@@ -10,7 +10,10 @@ export type CircleAnnotation = {
   /** Timestamp of circle */
   timestamp: Time;
 
-  /** Center of the circle in 2D image coordinates (pixels) */
+  /**
+   * Center of the circle in 2D image coordinates (pixels).
+   * The coordinate uses the top-left corner of the top-left pixel of the image as the origin.
+   */
   position: Point2;
 
   /** Circle diameter in pixels */

--- a/schemas/typescript/PointsAnnotation.ts
+++ b/schemas/typescript/PointsAnnotation.ts
@@ -14,7 +14,10 @@ export type PointsAnnotation = {
   /** Type of points annotation to draw */
   type: PointsAnnotationType;
 
-  /** Points in 2D image coordinates (pixels) */
+  /**
+   * Points in 2D image coordinates (pixels).
+   * These coordinates use the top-left corner of the top-left pixel of the image as the origin.
+   */
   points: Point2[];
 
   /** Outline color */

--- a/schemas/typescript/TextAnnotation.ts
+++ b/schemas/typescript/TextAnnotation.ts
@@ -10,7 +10,10 @@ export type TextAnnotation = {
   /** Timestamp of annotation */
   timestamp: Time;
 
-  /** Bottom-left origin of the text label in 2D image coordinates (pixels) */
+  /**
+   * Bottom-left origin of the text label in 2D image coordinates (pixels).
+   * The coordinate uses the top-left corner of the top-left pixel of the image as the origin.
+   */
   position: Point2;
 
   /** Text to display */


### PR DESCRIPTION
Update ImageAnnotation coordinate fields with comment specifying the coordinate space.


https://linear.app/foxglove/issue/FG-7672/update-docs-to-specify-image-annotation-coordinate-space