### PR TITLE
Fix python CI

### DIFF
--- a/python/foxglove-schemas-flatbuffer/setup.cfg
+++ b/python/foxglove-schemas-flatbuffer/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = foxglove-schemas-flatbuffer
-version = 0.1.0
+version = 0.2.0
 description = Flatbuffer classes for Foxglove Schemas
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/python/foxglove-schemas-protobuf/setup.cfg
+++ b/python/foxglove-schemas-protobuf/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = foxglove-schemas-protobuf
-version = 0.2.0
+version = 0.2.1
 description = Protobuf classes for Foxglove Schemas
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
Protobuf doesn't seem to have had big enough updates since the last release, so I just incremented the patch version.

Flatbuffers had field numbers added and I felt like that warranted a minor version bump.