### PR TITLE
Update RawImage schema with endianness

### DIFF
--- a/internal/__snapshots__/exportTypeScriptSchemas.test.ts.snap
+++ b/internal/__snapshots__/exportTypeScriptSchemas.test.ts.snap
@@ -821,7 +821,7 @@ export type RawImage = {
   /**
    * Encoding of the raw image data
    * 
-   * Supported values: \`8UC1\`, \`8UC3\`, \`16UC1\`, \`32FC1\`, \`bayer_bggr8\`, \`bayer_gbrg8\`, \`bayer_grbg8\`, \`bayer_rggb8\`, \`bgr8\`, \`bgra8\`, \`mono8\`, \`mono16\`, \`rgb8\`, \`rgba8\`, \`uyvy\` or \`yuv422\`, \`yuyv\` or \`yuv422_yuy2\`
+   * Supported values: \`8UC1\`, \`8UC3\`, \`16UC1\` (little endian), \`32FC1\` (little endian), \`bayer_bggr8\`, \`bayer_gbrg8\`, \`bayer_grbg8\`, \`bayer_rggb8\`, \`bgr8\`, \`bgra8\`, \`mono8\`, \`mono16\`, \`rgb8\`, \`rgba8\`, \`uyvy\` or \`yuv422\`, \`yuyv\` or \`yuv422_yuy2\`
    */
   encoding: string;
 

--- a/internal/schemas.ts
+++ b/internal/schemas.ts
@@ -852,7 +852,7 @@ const RawImage: FoxgloveMessageSchema = {
       name: "encoding",
       type: { type: "primitive", name: "string" },
       description:
-        "Encoding of the raw image data\n\nSupported values: `8UC1`, `8UC3`, `16UC1`, `32FC1`, `bayer_bggr8`, `bayer_gbrg8`, `bayer_grbg8`, `bayer_rggb8`, `bgr8`, `bgra8`, `mono8`, `mono16`, `rgb8`, `rgba8`, `uyvy` or `yuv422`, `yuyv` or `yuv422_yuy2`",
+        "Encoding of the raw image data\n\nSupported values: `8UC1`, `8UC3`, `16UC1` (little endian), `32FC1` (little endian), `bayer_bggr8`, `bayer_gbrg8`, `bayer_grbg8`, `bayer_rggb8`, `bgr8`, `bgra8`, `mono8`, `mono16`, `rgb8`, `rgba8`, `uyvy` or `yuv422`, `yuyv` or `yuv422_yuy2`",
     },
     {
       name: "step",

--- a/ros_foxglove_msgs/ros1/RawImage.msg
+++ b/ros_foxglove_msgs/ros1/RawImage.msg
@@ -17,7 +17,7 @@ uint32 height
 
 # Encoding of the raw image data
 # 
-# Supported values: `8UC1`, `8UC3`, `16UC1`, `32FC1`, `bayer_bggr8`, `bayer_gbrg8`, `bayer_grbg8`, `bayer_rggb8`, `bgr8`, `bgra8`, `mono8`, `mono16`, `rgb8`, `rgba8`, `uyvy` or `yuv422`, `yuyv` or `yuv422_yuy2`
+# Supported values: `8UC1`, `8UC3`, `16UC1` (little endian), `32FC1` (little endian), `bayer_bggr8`, `bayer_gbrg8`, `bayer_grbg8`, `bayer_rggb8`, `bgr8`, `bgra8`, `mono8`, `mono16`, `rgb8`, `rgba8`, `uyvy` or `yuv422`, `yuyv` or `yuv422_yuy2`
 string encoding
 
 # Byte length of a single row

--- a/ros_foxglove_msgs/ros2/RawImage.msg
+++ b/ros_foxglove_msgs/ros2/RawImage.msg
@@ -17,7 +17,7 @@ uint32 height
 
 # Encoding of the raw image data
 # 
-# Supported values: `8UC1`, `8UC3`, `16UC1`, `32FC1`, `bayer_bggr8`, `bayer_gbrg8`, `bayer_grbg8`, `bayer_rggb8`, `bgr8`, `bgra8`, `mono8`, `mono16`, `rgb8`, `rgba8`, `uyvy` or `yuv422`, `yuyv` or `yuv422_yuy2`
+# Supported values: `8UC1`, `8UC3`, `16UC1` (little endian), `32FC1` (little endian), `bayer_bggr8`, `bayer_gbrg8`, `bayer_grbg8`, `bayer_rggb8`, `bgr8`, `bgra8`, `mono8`, `mono16`, `rgb8`, `rgba8`, `uyvy` or `yuv422`, `yuyv` or `yuv422_yuy2`
 string encoding
 
 # Byte length of a single row

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -2287,7 +2287,7 @@ string
 
 Encoding of the raw image data
 
-Supported values: `8UC1`, `8UC3`, `16UC1`, `32FC1`, `bayer_bggr8`, `bayer_gbrg8`, `bayer_grbg8`, `bayer_rggb8`, `bgr8`, `bgra8`, `mono8`, `mono16`, `rgb8`, `rgba8`, `uyvy` or `yuv422`, `yuyv` or `yuv422_yuy2`
+Supported values: `8UC1`, `8UC3`, `16UC1` (little endian), `32FC1` (little endian), `bayer_bggr8`, `bayer_gbrg8`, `bayer_grbg8`, `bayer_rggb8`, `bgr8`, `bgra8`, `mono8`, `mono16`, `rgb8`, `rgba8`, `uyvy` or `yuv422`, `yuyv` or `yuv422_yuy2`
 
 </td>
 </tr>

--- a/schemas/flatbuffer/RawImage.fbs
+++ b/schemas/flatbuffer/RawImage.fbs
@@ -20,7 +20,7 @@ table RawImage {
 
   /// Encoding of the raw image data
   /// 
-  /// Supported values: `8UC1`, `8UC3`, `16UC1`, `32FC1`, `bayer_bggr8`, `bayer_gbrg8`, `bayer_grbg8`, `bayer_rggb8`, `bgr8`, `bgra8`, `mono8`, `mono16`, `rgb8`, `rgba8`, `uyvy` or `yuv422`, `yuyv` or `yuv422_yuy2`
+  /// Supported values: `8UC1`, `8UC3`, `16UC1` (little endian), `32FC1` (little endian), `bayer_bggr8`, `bayer_gbrg8`, `bayer_grbg8`, `bayer_rggb8`, `bgr8`, `bgra8`, `mono8`, `mono16`, `rgb8`, `rgba8`, `uyvy` or `yuv422`, `yuyv` or `yuv422_yuy2`
   encoding:string (id: 4);
 
   /// Byte length of a single row

--- a/schemas/jsonschema/RawImage.json
+++ b/schemas/jsonschema/RawImage.json
@@ -36,7 +36,7 @@
     },
     "encoding": {
       "type": "string",
-      "description": "Encoding of the raw image data\n\nSupported values: `8UC1`, `8UC3`, `16UC1`, `32FC1`, `bayer_bggr8`, `bayer_gbrg8`, `bayer_grbg8`, `bayer_rggb8`, `bgr8`, `bgra8`, `mono8`, `mono16`, `rgb8`, `rgba8`, `uyvy` or `yuv422`, `yuyv` or `yuv422_yuy2`"
+      "description": "Encoding of the raw image data\n\nSupported values: `8UC1`, `8UC3`, `16UC1` (little endian), `32FC1` (little endian), `bayer_bggr8`, `bayer_gbrg8`, `bayer_grbg8`, `bayer_rggb8`, `bgr8`, `bgra8`, `mono8`, `mono16`, `rgb8`, `rgba8`, `uyvy` or `yuv422`, `yuyv` or `yuv422_yuy2`"
     },
     "step": {
       "type": "integer",

--- a/schemas/jsonschema/index.ts
+++ b/schemas/jsonschema/index.ts
@@ -4628,7 +4628,7 @@ export const RawImage = {
     },
     "encoding": {
       "type": "string",
-      "description": "Encoding of the raw image data\n\nSupported values: `8UC1`, `8UC3`, `16UC1`, `32FC1`, `bayer_bggr8`, `bayer_gbrg8`, `bayer_grbg8`, `bayer_rggb8`, `bgr8`, `bgra8`, `mono8`, `mono16`, `rgb8`, `rgba8`, `uyvy` or `yuv422`, `yuyv` or `yuv422_yuy2`"
+      "description": "Encoding of the raw image data\n\nSupported values: `8UC1`, `8UC3`, `16UC1` (little endian), `32FC1` (little endian), `bayer_bggr8`, `bayer_gbrg8`, `bayer_grbg8`, `bayer_rggb8`, `bgr8`, `bgra8`, `mono8`, `mono16`, `rgb8`, `rgba8`, `uyvy` or `yuv422`, `yuyv` or `yuv422_yuy2`"
     },
     "step": {
       "type": "integer",

--- a/schemas/omgidl/foxglove/RawImage.idl
+++ b/schemas/omgidl/foxglove/RawImage.idl
@@ -20,7 +20,7 @@ struct RawImage {
 
   // Encoding of the raw image data
   // 
-  // Supported values: `8UC1`, `8UC3`, `16UC1`, `32FC1`, `bayer_bggr8`, `bayer_gbrg8`, `bayer_grbg8`, `bayer_rggb8`, `bgr8`, `bgra8`, `mono8`, `mono16`, `rgb8`, `rgba8`, `uyvy` or `yuv422`, `yuyv` or `yuv422_yuy2`
+  // Supported values: `8UC1`, `8UC3`, `16UC1` (little endian), `32FC1` (little endian), `bayer_bggr8`, `bayer_gbrg8`, `bayer_grbg8`, `bayer_rggb8`, `bgr8`, `bgra8`, `mono8`, `mono16`, `rgb8`, `rgba8`, `uyvy` or `yuv422`, `yuyv` or `yuv422_yuy2`
   string encoding;
 
   // Byte length of a single row

--- a/schemas/proto/foxglove/RawImage.proto
+++ b/schemas/proto/foxglove/RawImage.proto
@@ -22,7 +22,7 @@ message RawImage {
 
   // Encoding of the raw image data
   // 
-  // Supported values: `8UC1`, `8UC3`, `16UC1`, `32FC1`, `bayer_bggr8`, `bayer_gbrg8`, `bayer_grbg8`, `bayer_rggb8`, `bgr8`, `bgra8`, `mono8`, `mono16`, `rgb8`, `rgba8`, `uyvy` or `yuv422`, `yuyv` or `yuv422_yuy2`
+  // Supported values: `8UC1`, `8UC3`, `16UC1` (little endian), `32FC1` (little endian), `bayer_bggr8`, `bayer_gbrg8`, `bayer_grbg8`, `bayer_rggb8`, `bgr8`, `bgra8`, `mono8`, `mono16`, `rgb8`, `rgba8`, `uyvy` or `yuv422`, `yuyv` or `yuv422_yuy2`
   string encoding = 4;
 
   // Byte length of a single row

--- a/schemas/ros1/RawImage.msg
+++ b/schemas/ros1/RawImage.msg
@@ -17,7 +17,7 @@ uint32 height
 
 # Encoding of the raw image data
 # 
-# Supported values: `8UC1`, `8UC3`, `16UC1`, `32FC1`, `bayer_bggr8`, `bayer_gbrg8`, `bayer_grbg8`, `bayer_rggb8`, `bgr8`, `bgra8`, `mono8`, `mono16`, `rgb8`, `rgba8`, `uyvy` or `yuv422`, `yuyv` or `yuv422_yuy2`
+# Supported values: `8UC1`, `8UC3`, `16UC1` (little endian), `32FC1` (little endian), `bayer_bggr8`, `bayer_gbrg8`, `bayer_grbg8`, `bayer_rggb8`, `bgr8`, `bgra8`, `mono8`, `mono16`, `rgb8`, `rgba8`, `uyvy` or `yuv422`, `yuyv` or `yuv422_yuy2`
 string encoding
 
 # Byte length of a single row

--- a/schemas/ros2/RawImage.msg
+++ b/schemas/ros2/RawImage.msg
@@ -17,7 +17,7 @@ uint32 height
 
 # Encoding of the raw image data
 # 
-# Supported values: `8UC1`, `8UC3`, `16UC1`, `32FC1`, `bayer_bggr8`, `bayer_gbrg8`, `bayer_grbg8`, `bayer_rggb8`, `bgr8`, `bgra8`, `mono8`, `mono16`, `rgb8`, `rgba8`, `uyvy` or `yuv422`, `yuyv` or `yuv422_yuy2`
+# Supported values: `8UC1`, `8UC3`, `16UC1` (little endian), `32FC1` (little endian), `bayer_bggr8`, `bayer_gbrg8`, `bayer_grbg8`, `bayer_rggb8`, `bgr8`, `bgra8`, `mono8`, `mono16`, `rgb8`, `rgba8`, `uyvy` or `yuv422`, `yuyv` or `yuv422_yuy2`
 string encoding
 
 # Byte length of a single row

--- a/schemas/typescript/RawImage.ts
+++ b/schemas/typescript/RawImage.ts
@@ -20,7 +20,7 @@ export type RawImage = {
   /**
    * Encoding of the raw image data
    * 
-   * Supported values: `8UC1`, `8UC3`, `16UC1`, `32FC1`, `bayer_bggr8`, `bayer_gbrg8`, `bayer_grbg8`, `bayer_rggb8`, `bgr8`, `bgra8`, `mono8`, `mono16`, `rgb8`, `rgba8`, `uyvy` or `yuv422`, `yuyv` or `yuv422_yuy2`
+   * Supported values: `8UC1`, `8UC3`, `16UC1` (little endian), `32FC1` (little endian), `bayer_bggr8`, `bayer_gbrg8`, `bayer_grbg8`, `bayer_rggb8`, `bgr8`, `bgra8`, `mono8`, `mono16`, `rgb8`, `rgba8`, `uyvy` or `yuv422`, `yuyv` or `yuv422_yuy2`
    */
   encoding: string;
 


### PR DESCRIPTION
### Changelog
<!-- Write a one-sentence summary of the user-impacting change (API, UI/UX, performance, etc) that could appear in a changelog. Write "None" if there is no user-facing change -->
 - specify that `16UC1` and `32FC1` are interpreted as little endian

### Docs

<!-- Link to a Docs PR, tracking ticket in Linear, OR write "None" if no documentation changes are needed. -->

### Description

Specify that `16UC1` and `32FC1` are interpreted as little endian

<!-- Describe the problem, what has changed, and motivation behind those changes. Pretend you are advocating for this change and the reader is skeptical. -->

<!-- In addition to unit tests, describe any manual testing you did to validate this change. -->

<table><tr><th>Before</th><th>After</th></tr><tr><td>

<!--before content goes here-->

</td><td>

<!--after content goes here-->

</td></tr></table>

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->

FG-8171
