### PR TITLE
Fix PyPI publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,7 @@ jobs:
           packages_dir: python/foxglove-schemas-flatbuffer/dist
           repository_url: https://test.pypi.org/legacy/
           skip_existing: true
+          attestations: false # https://github.com/pypa/gh-action-pypi-publish/issues/283#issuecomment-2499296440
 
       - name: Publish foxglove-schemas-flatbuffer to PyPI
         if: |
@@ -115,6 +116,7 @@ jobs:
           packages_dir: python/foxglove-schemas-protobuf/dist
           repository_url: https://test.pypi.org/legacy/
           skip_existing: true
+          attestations: false # https://github.com/pypa/gh-action-pypi-publish/issues/283#issuecomment-2499296440
 
       - name: Publish foxglove-schemas-protobuf to PyPI
         if: |


### PR DESCRIPTION
Running a publish to TestPyPI immediately followed by a publish to the "real" PyPI triggered [an error](https://github.com/foxglove/schemas/actions/runs/12283736365/job/34277883747) due to a file already existing. The workaround recommended in https://github.com/pypa/gh-action-pypi-publish/issues/283#issuecomment-2499296440 is to set `attestations: false` on the TestPyPI publish.