### PR TITLE
Fix CI errors due to ubuntu 24.04 image rollout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
 
   python:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04 # Required for python 3.7
     defaults:
       run:
         working-directory: python


### PR DESCRIPTION
### Changelog
<!-- Write a one-sentence summary of the user-impacting change (API, UI/UX, performance, etc) that could appear in a changelog. Write "None" if there is no user-facing change -->

None

### Docs

<!-- Link to a Docs PR, tracking ticket in Linear, OR write "None" if no documentation changes are needed. -->

None

### Description

<!-- Describe the problem, what has changed, and motivation behind those changes. Pretend you are advocating for this change and the reader is skeptical. -->

CI [broke recently](https://github.com/foxglove/schemas/actions/runs/12341162294/job/34439471378?pr=159) because Python 3.7 is not supported for Ubuntu 24.04 x64. See https://github.com/actions/setup-python/issues/962. This fixes the `python` job to use Ubuntu 22.04.