### PR TITLE
appease node v22

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,5 +53,6 @@
   "dependencies": {
     "@foxglove/rosmsg-msgs-common": "^3.0.0",
     "tslib": "^2.5.0"
-  }
+  },
+  "packageManager": "yarn@1.22.19+sha1.4ba7fc5c6e704fce2066ecbfb0b0d8976fe62447"
 }


### PR DESCRIPTION
### Changelog
None
### Docs

None
### Description

Running yarn install on a newer version adds this to package.json. Committing it to the repo to avoid future random unstaged changes.